### PR TITLE
Add StringFormatValidator and Test

### DIFF
--- a/app/validators/string_format_validator.rb
+++ b/app/validators/string_format_validator.rb
@@ -1,0 +1,22 @@
+class StringFormatValidator < ActiveModel::EachValidator
+  VALIDATIONS = {
+    starts_with_non_whitespace: { regex: /\A\S/, message: "can't start with whitespace", },
+    ends_with_non_whitespace: { regex: /\S\z/, message: "can't end with whitespace", },
+    has_only_printable_characters: { regex: /\A[[:print:]]*\z/, message: 'can only contain printable characters', }
+  }
+
+  def validate_each(record, attribute, value)
+    rules = options.fetch(:rules, [])
+    validate_string_format(record, attribute, value, rules)
+  end
+
+  private
+
+  def validate_string_format(record, attribute, value, rules)
+    rules.each do |rule|
+      validator = VALIDATIONS.fetch(rule)
+      next if validator.nil? || (validator.fetch(:regex) =~ value)
+      record.errors.add(attribute, validator.fetch(:message))
+    end
+  end
+end

--- a/test/string_format_assertions.rb
+++ b/test/string_format_assertions.rb
@@ -1,0 +1,9 @@
+module Minitest
+  module Assertions
+    def assert_validates_format_rules(expected_rules, klass, attribute)
+      name_format_validators = klass.validators_on(attribute).select { |v| v.class == StringFormatValidator }
+      existing_rules = name_format_validators.flat_map { |v| v.options[:rules] }
+      assert_equal expected_rules, existing_rules
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'string_format_assertions'
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.

--- a/test/validators/string_format_validator_test.rb
+++ b/test/validators/string_format_validator_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class StringFormatValidatorTest < ActiveSupport::TestCase
+  class FooClass
+    include ActiveModel::Validations
+    attr_reader :bar
+    def initialize(bar)
+      @bar = bar
+    end
+  end
+
+  test 'contains the expected set of validation rules' do
+    expected_rules = [
+      :starts_with_non_whitespace,
+      :ends_with_non_whitespace,
+      :has_only_printable_characters
+    ]
+    existing_rules = StringFormatValidator::VALIDATIONS.keys
+    assert_equal expected_rules, existing_rules
+  end
+
+  test ':starts_with_non_whitespace rule checks that the value does not begin with any whitespace' do
+    FooClass.validates(:bar, string_format: { rules: [:starts_with_non_whitespace] })
+    foo = FooClass.new(' startswithwhitespace')
+    foo.validate
+    assert_includes foo.errors[:bar], "can't start with whitespace"
+  end
+
+  test ':ends_with_non_whitespace rule checks that the value does not end with any whitespace' do
+    FooClass.validates(:bar, string_format: { rules: [:ends_with_non_whitespace] })
+    foo = FooClass.new('endswithwhitespace ')
+    foo.validate
+    assert_includes foo.errors[:bar], "can't end with whitespace"
+  end
+
+  test ':has_only_printable_characters rule checks that the value can only contain printable characters' do
+    FooClass.validates(:bar, string_format: { rules: [:has_only_printable_characters] })
+    foo = FooClass.new("\x0A")
+    foo.validate
+    assert_includes foo.errors[:bar], 'can only contain printable characters'
+  end
+end


### PR DESCRIPTION
## Problem

There will be many validations required for various string formats, and as a result, there will be a lot of duplicate code.

## Solution

Add a custom `StringFormatValidator` along with a custom assertion `assert_validates_format_rules` to use in model tests with those validations.

## How it's Used

In use, you might have a test for a model `Foo` and want to check that certain validations exist on it's `:bar` property.

```ruby
class FooTest < ActiveSupport::TestCase
  test 'bar attribute validates with the expected rules' do
    expected_rules = [:starts_with_non_whitespace, :has_only_printable_characters]
    assert_validates_format_rules expected_rules, Foo, :bar
  end
end
```