### PR TITLE
Add Game Model

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,0 +1,2 @@
+class Game < ApplicationRecord
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,2 +1,10 @@
 class Game < ApplicationRecord
+  validates :title,
+    presence: true,
+    allow_blank: false,
+    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters] }
+  validates :description,
+    presence: true,
+    allow_blank: false,
+    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters] }
 end

--- a/db/migrate/20170129233937_create_games.rb
+++ b/db/migrate/20170129233937_create_games.rb
@@ -1,0 +1,10 @@
+class CreateGames < ActiveRecord::Migration[5.0]
+  def change
+    create_table :games do |t|
+      t.string :title
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170111005636) do
+ActiveRecord::Schema.define(version: 20170129233937) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "games", force: :cascade do |t|
+    t.string   "title"
+    t.text     "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "username"

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -5,6 +5,13 @@ class GameTest < ActiveSupport::TestCase
     @game ||= Game.new(title: 'Game Title', description: 'The best game ever.')
   end
 
+  test 'saves a game to the database' do
+    Game.destroy_all
+    game.save
+    assert game.errors.empty?
+    assert_equal 1, Game.count
+  end
+
   test 'without a title, is invalid' do
     game.title = nil
     game.validate

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class GameTest < ActiveSupport::TestCase
+  def game
+    @game ||= Game.new(title: 'Game Title', description: 'The best game ever.')
+  end
+
+  test 'without a title, is invalid' do
+    game.title = nil
+    game.validate
+    assert_includes game.errors[:title], "can't be blank"
+  end
+
+  test 'with blank title, is invalid' do
+    game.title = ''
+    game.validate
+    assert_includes game.errors[:title], "can't be blank"
+  end
+
+  test 'title is formatted with the expected rules' do
+    expected_validation_rules = [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters]
+    assert_validates_format_rules expected_validation_rules, Game, :title
+  end
+
+  test 'without a description, is invalid' do
+    game.description = nil
+    game.validate
+    assert_includes game.errors[:description], "can't be blank"
+  end
+
+  test 'with a blank description, is invalid' do
+    game.description = ''
+    game.validate
+    assert_includes game.errors[:description], "can't be blank"
+  end
+
+  test 'description is formatted with the expected rules' do
+    expected_validation_rules = [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters]
+    assert_validates_format_rules expected_validation_rules, Game, :description
+  end
+end


### PR DESCRIPTION
## Game Model

PR includes non-association properties `title`, and `description`.  Includes `Game` model, migration, unit tests, and updated schema.

___

related: https://github.com/allegroplanet/allegro-planet/issues/9