### PR TITLE
Add User<->Game Association

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -10,4 +10,6 @@ class Game < ApplicationRecord
     string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters] }
 
   has_many :game_screenshots
+
+  has_and_belongs_to_many :users
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,8 @@ class User < ApplicationRecord
   validates :password, format: { with: StringFormat::ENDS_WITH_NON_WHITESPACE,
                                  message: 'can not end with whitespace' }
 
+  has_and_belongs_to_many :games
+
   private
 
     def generate_slug

--- a/db/migrate/20170224034506_create_games_users_join_table.rb
+++ b/db/migrate/20170224034506_create_games_users_join_table.rb
@@ -1,0 +1,11 @@
+class CreateGamesUsersJoinTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :games_users, id: false do |t|
+      t.integer :game_id
+      t.integer :user_id
+    end
+
+    add_index :games_users, :game_id
+    add_index :games_users, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170224015014) do
+ActiveRecord::Schema.define(version: 20170224034506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,13 @@ ActiveRecord::Schema.define(version: 20170224015014) do
     t.text     "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+  end
+
+  create_table "games_users", id: false, force: :cascade do |t|
+    t.integer "game_id"
+    t.integer "user_id"
+    t.index ["game_id"], name: "index_games_users_on_game_id", using: :btree
+    t.index ["user_id"], name: "index_games_users_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -54,4 +54,9 @@ class GameTest < ActiveSupport::TestCase
     associations = game_associations(:has_many, :game_screenshots)
     assert associations.one?
   end
+
+  test 'has and belongs to many users' do
+    associations = game_associations(:has_and_belongs_to_many, :users)
+    assert associations.one?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
+  def user_associations(association_type, property)
+    User.reflect_on_all_associations(association_type).select { |a| a.name == property }
+  end
 
   def user
     @user ||= User.new(username: 'mr. test',
@@ -122,5 +125,10 @@ class UserTest < ActiveSupport::TestCase
     user.username = username_that_already_exists
     user.save
     assert_includes user.errors[:slug], 'has already been taken'
+  end
+
+  test 'has and belongs to many games' do
+    associations = user_associations(:has_and_belongs_to_many, :games)
+    assert associations.one?
   end
 end


### PR DESCRIPTION
### Games Need to have Developers

This PR adds a `has_and_belongs_to_many` association between `User` and `Game`.  Includes tests, migration on a join table.