### PR TITLE
Add slug to Game; Allow URL to 

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -4,7 +4,7 @@ class GamesController < ApplicationController
   end
 
   def show
-    @game = Game.find(params[:id])
+    @game = Game.find_by(slug: params[:slug]) or record_not_found
     @screenshot_urls = @game.game_screenshots.collect { |s| s.image.url }
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,4 +1,6 @@
 class Game < ApplicationRecord
+  before_validation :generate_slug
+
   validates :title,
     presence: true,
     uniqueness: true,
@@ -13,4 +15,10 @@ class Game < ApplicationRecord
   has_many :game_screenshots
 
   has_and_belongs_to_many :users
+
+  private
+
+    def generate_slug
+      self.slug ||= self.title.parameterize if self.title.present?
+    end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,6 +1,7 @@
 class Game < ApplicationRecord
   validates :title,
     presence: true,
+    uniqueness: true,
     allow_blank: false,
     string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters] }
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -12,6 +12,10 @@ class Game < ApplicationRecord
     allow_blank: false,
     string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters] }
 
+  validates :slug,
+    presence: true,
+    uniqueness: true
+
   has_many :game_screenshots
 
   has_and_belongs_to_many :users

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -2,6 +2,6 @@
 
 <ul>
   <% @games.each do |game| %>
-    <li><p><%= link_to(game.title, "/depot/games/#{game.id}") %></li>
+    <li><p><%= link_to(game.title, "/depot/games/#{game.slug}") %></li>
   <% end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   get '/depot', to: 'games#index'
-  get '/depot/games/:id', to: 'games#show'
+  get '/depot/games/:slug', to: 'games#show'
 
   resources :users, param: :slug, only: [:show]
   get '/signup', to: 'users#new'

--- a/db/migrate/20170225165641_add_slug_to_games.rb
+++ b/db/migrate/20170225165641_add_slug_to_games.rb
@@ -1,0 +1,5 @@
+class AddSlugToGames < ActiveRecord::Migration[5.0]
+  def change
+    add_column :games, :slug, :string, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170224034506) do
+ActiveRecord::Schema.define(version: 20170225165641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20170224034506) do
     t.text     "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "slug"
   end
 
   create_table "games_users", id: false, force: :cascade do |t|

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -7,7 +7,7 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'GET #show is successful' do
-    get "/depot/games/#{games(:alex_adventures).id}"
+    get "/depot/games/#{games(:alex_adventures).slug}"
     assert_response :success
   end
 end

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -1,6 +1,8 @@
 alex_adventures:
   title: Alex Adventures
   description: Join Alex as he explores the vast underbelly of modern society.
+  slug: alex-adventures
 super_biker:
   title: Super Biker
   description: A fast-paced action racer.
+  slug: super-biker

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -61,6 +61,13 @@ class GameTest < ActiveSupport::TestCase
     assert_equal game.slug, 'game-title'
   end
 
+  test 'with a slug that already exists, is invalid' do
+    game_title_that_already_exists = games(:alex_adventures).title
+    game.title = game_title_that_already_exists
+    game.validate
+    assert_includes game.errors[:slug], 'has already been taken'
+  end
+
   test 'has many game screenshots' do
     associations = game_associations(:has_many, :game_screenshots)
     assert associations.one?

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -16,6 +16,12 @@ class GameTest < ActiveSupport::TestCase
     assert_equal 1, Game.count
   end
 
+  test 'without a unique title, is invalid' do
+    game.title = games(:alex_adventures).title
+    game.validate
+    assert_includes game.errors[:title], 'has already been taken'
+  end
+
   test 'without a title, is invalid' do
     game.title = nil
     game.validate

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -56,6 +56,11 @@ class GameTest < ActiveSupport::TestCase
     assert_validates_format_rules expected_validation_rules, Game, :description
   end
 
+  test 'generates a slug on validation' do
+    game.validate
+    assert_equal game.slug, 'game-title'
+  end
+
   test 'has many game screenshots' do
     associations = game_associations(:has_many, :game_screenshots)
     assert associations.one?


### PR DESCRIPTION
### Problem

URLs currently use IDs to retrieve records:
`http://www.asdf.com/depot/games/1`

Instead, URLs should use the slug:
`http://www.asdf.com/depot/games/name-of-game`

### Solution

- Add `slug` to `Game` (through the `games` table in the database)
- Add a path to `depot/games/:slug` so URLs can use the slug

### Also

- Require a unique game title (no duplicate titles or URLs or slugs)

___

/cc @amarillion 

___

/ fixes https://github.com/allegroplanet/allegro-planet/issues/16