### PR TITLE
Add GameFiles

### DIFF
--- a/app/models/game_file.rb
+++ b/app/models/game_file.rb
@@ -1,9 +1,12 @@
 class GameFile < ApplicationRecord
-  GAME_FILE_CATEGORIES = ['MacOS binary', 'Win binary', 'Linux binary', 'Data file', 'Source files', 'Other'].freeze
+  GAME_FILE_CATEGORIES = ['MacOS binary', 'Win binary', 'Linux binary', 'Data files', 'Source files', 'Other'].freeze
+  INCLUSION_MESSAGE = "must be one of #{GAME_FILE_CATEGORIES}"
 
   mount_uploader :file, GameFileUploader
 
-  validates :category, inclusion: { in: GAME_FILE_CATEGORIES, message: "\"%{value}\" is not a valid value" }
+  validates :category,
+    presence: { message: INCLUSION_MESSAGE },
+    inclusion: { in: GAME_FILE_CATEGORIES, message: INCLUSION_MESSAGE }
 
   belongs_to :game_release
 end

--- a/app/models/game_file.rb
+++ b/app/models/game_file.rb
@@ -4,4 +4,6 @@ class GameFile < ApplicationRecord
   mount_uploader :file, GameFileUploader
 
   validates :category, inclusion: { in: GAME_FILE_CATEGORIES, message: "\"%{value}\" is not a valid value" }
+
+  belongs_to :game_release
 end

--- a/app/models/game_file.rb
+++ b/app/models/game_file.rb
@@ -1,2 +1,3 @@
 class GameFile < ApplicationRecord
+  mount_uploader :file, GameFileUploader
 end

--- a/app/models/game_file.rb
+++ b/app/models/game_file.rb
@@ -1,3 +1,7 @@
 class GameFile < ApplicationRecord
+  GAME_FILE_CATEGORIES = ['MacOS binary', 'Win binary', 'Linux binary', 'Data file', 'Source files', 'Other'].freeze
+
   mount_uploader :file, GameFileUploader
+
+  validates :category, inclusion: { in: GAME_FILE_CATEGORIES, message: "\"%{value}\" is not a valid value" }
 end

--- a/app/models/game_file.rb
+++ b/app/models/game_file.rb
@@ -1,0 +1,2 @@
+class GameFile < ApplicationRecord
+end

--- a/app/models/game_release.rb
+++ b/app/models/game_release.rb
@@ -6,4 +6,6 @@ class GameRelease < ApplicationRecord
     string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters] }
 
   belongs_to :game
+
+  has_many :game_files
 end

--- a/app/uploaders/game_file_uploader.rb
+++ b/app/uploaders/game_file_uploader.rb
@@ -1,0 +1,10 @@
+class GameFileUploader < CarrierWave::Uploader::Base
+  def store_dir
+    'game-files'
+  end
+
+  def extension_whitelist
+    ['zip']
+  end
+end
+

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -60,4 +60,16 @@ RailsAdmin.config do |config|
       end
     end
   end
+
+  # GameRelease
+
+  config.model 'GameRelease' do
+    object_label_method do
+      :game_release_label_method
+    end
+  end
+
+  def game_release_label_method
+    "#{self.game.slug}-#{self.version_num}"
+  end
 end

--- a/db/migrate/20170226080301_create_game_files.rb
+++ b/db/migrate/20170226080301_create_game_files.rb
@@ -1,0 +1,10 @@
+class CreateGameFiles < ActiveRecord::Migration[5.0]
+  def change
+    create_table :game_files do |t|
+      t.string :file
+      t.string :category
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170226084857_add_game_release_reference_to_game_file.rb
+++ b/db/migrate/20170226084857_add_game_release_reference_to_game_file.rb
@@ -1,0 +1,5 @@
+class AddGameReleaseReferenceToGameFile < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :game_files, :game_release, forign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170226080301) do
+ActiveRecord::Schema.define(version: 20170226084857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,8 +18,10 @@ ActiveRecord::Schema.define(version: 20170226080301) do
   create_table "game_files", force: :cascade do |t|
     t.string   "file"
     t.string   "category"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.integer  "game_release_id"
+    t.index ["game_release_id"], name: "index_game_files_on_game_release_id", using: :btree
   end
 
   create_table "game_releases", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170226065723) do
+ActiveRecord::Schema.define(version: 20170226080301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "game_files", force: :cascade do |t|
+    t.string   "file"
+    t.string   "category"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "game_releases", force: :cascade do |t|
     t.string   "version_num"

--- a/test/models/game_file_test.rb
+++ b/test/models/game_file_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class GameFileTest < ActiveSupport::TestCase
+  def game_file
+    @game_file ||= GameFile.new({
+      file: 'filename.zip',
+      category: 'Source files'
+    })
+  end
+
+  test 'validates without errors' do
+    game_file.validate
+    assert game_file.errors.empty?
+  end
+
+  test 'can have a valid category' do
+    GameFile::GAME_FILE_CATEGORIES.each do |category|
+      game_file.category = category
+      game_file.validate
+      assert game_file.errors[:category].empty?
+    end
+  end
+
+  test 'with an category that is not a known category, is invalid' do
+    game_file.category = 'Not a known category'
+    game_file.validate
+    assert_includes game_file.errors[:category], '"Not a known category" is not a valid value'
+  end
+end

--- a/test/models/game_file_test.rb
+++ b/test/models/game_file_test.rb
@@ -18,6 +18,12 @@ class GameFileTest < ActiveSupport::TestCase
     assert game_file.errors.empty?
   end
 
+  test 'without a category, is invalid' do
+    game_file.category = nil
+    game_file.validate
+    assert_includes game_file.errors[:category], GameFile::INCLUSION_MESSAGE
+  end
+
   test 'can have a valid category' do
     GameFile::GAME_FILE_CATEGORIES.each do |category|
       game_file.category = category
@@ -29,7 +35,7 @@ class GameFileTest < ActiveSupport::TestCase
   test 'with an category that is not a known category, is invalid' do
     game_file.category = 'Not a known category'
     game_file.validate
-    assert_includes game_file.errors[:category], '"Not a known category" is not a valid value'
+    assert_includes game_file.errors[:category], GameFile::INCLUSION_MESSAGE
   end
 
   test 'belongs_to to a game_release' do

--- a/test/models/game_file_test.rb
+++ b/test/models/game_file_test.rb
@@ -42,4 +42,8 @@ class GameFileTest < ActiveSupport::TestCase
     associations = game_file_associations(:belongs_to, :game_release)
     assert associations.one?
   end
+
+  test 'has the expected category error message' do
+    assert_equal GameFile::INCLUSION_MESSAGE, "must be one of #{GameFile::GAME_FILE_CATEGORIES}"
+  end
 end

--- a/test/models/game_file_test.rb
+++ b/test/models/game_file_test.rb
@@ -1,10 +1,15 @@
 require 'test_helper'
 
 class GameFileTest < ActiveSupport::TestCase
+  def game_file_associations(association_type, property)
+    GameFile.reflect_on_all_associations(association_type).select { |a| a.name == property }
+  end
+
   def game_file
     @game_file ||= GameFile.new({
       file: 'filename.zip',
-      category: 'Source files'
+      category: 'Source files',
+      game_release: game_releases(:release_1)
     })
   end
 
@@ -25,5 +30,10 @@ class GameFileTest < ActiveSupport::TestCase
     game_file.category = 'Not a known category'
     game_file.validate
     assert_includes game_file.errors[:category], '"Not a known category" is not a valid value'
+  end
+
+  test 'belongs_to to a game_release' do
+    associations = game_file_associations(:belongs_to, :game_release)
+    assert associations.one?
   end
 end

--- a/test/models/game_release_test.rb
+++ b/test/models/game_release_test.rb
@@ -53,4 +53,9 @@ class GameReleaseTest < ActiveSupport::TestCase
     game_release.validate
     assert_includes game_release.errors[:game], 'must exist'
   end
+
+  test 'has_many to a game_files' do
+    associations = game_release_associations(:has_many, :game_files)
+    assert associations.one?
+  end
 end


### PR DESCRIPTION
### Releases need to have downloadable files

This PR adds:
- A `GameFileUploader` that uploads files to S3 at `/game-files/game-filename.zip'
- `zip` files only
- Adds associations between `GameRelease` <-> `GameFile`