### PR TITLE
Show releases and game files

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -6,5 +6,6 @@ class GamesController < ApplicationController
   def show
     @game = Game.find_by(slug: params[:slug]) or record_not_found
     @screenshot_urls = @game.game_screenshots.collect { |s| s.image.url }
+    @releases = @game.game_releases
   end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -9,3 +9,15 @@
     <%= image_tag(screenshot_url) %>
   <% end %>
 </div>
+
+<h3>Releases (<%= @releases.count %>)</h3>
+<div>
+  <% @releases.each do |release| %>
+    <h4><%= release.version_num %></h4>
+    <ul>
+    <% release.game_files.each do |game_file| %>
+      <li><%= link_to(game_file.category, game_file.file.url) %></li>
+    <% end %>
+    </ul>
+  <% end %>
+</div>


### PR DESCRIPTION
### Problem

On a game's page, it currently only show title, description, and screenshots.  There is no downloadable files or information about releases.

### Solution

Add a very simple front-end to list release versions and the files associated with them.