### PR TITLE
Improve path helpers

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -22,6 +22,10 @@ class Game < ApplicationRecord
 
   has_and_belongs_to_many :users
 
+  def to_param
+    slug
+  end
+
   private
 
     def generate_slug

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,10 @@ class User < ApplicationRecord
 
   has_and_belongs_to_many :games
 
+  def to_param
+    slug
+  end
+
   private
 
     def generate_slug

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Depot</h1>
+<h1>Games</h1>
 
 <ul>
   <% @games.each do |game| %>

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -2,6 +2,6 @@
 
 <ul>
   <% @games.each do |game| %>
-    <li><p><%= link_to(game.title, "/depot/games/#{game.slug}") %></li>
+    <li><p><%= link_to(game.title, game) %></li>
   <% end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,7 @@ Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   root 'welcome#index'
 
-  get '/depot', to: 'games#index'
-  get '/depot/games/:slug', to: 'games#show'
+  resources :games, param: :slug, only: [:index, :show]
 
   resources :users, param: :slug, only: [:show]
   get '/signup', to: 'users#new'

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -2,12 +2,12 @@ require 'test_helper'
 
 class GamesControllerTest < ActionDispatch::IntegrationTest
   test 'GET #index is successful' do
-    get depot_url
+    get games_url
     assert_response :success
   end
 
   test 'GET #show is successful' do
-    get "/depot/games/#{games(:alex_adventures).slug}"
+    get game_path(games(:alex_adventures))
     assert_response :success
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -6,12 +6,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'GET #show is successful' do
-    get user_path(user.slug)
+    get user_path(user)
     assert_response :success
   end
 
   test 'GET #show renders the "show" template' do
-    get user_path(user.slug)
+    get user_path(user)
     assert_template :show
   end
 


### PR DESCRIPTION
### Problem

Prior to this PR, we would have to build paths to records manually, e.g. `depot/games/#{game.slug}`.  However, this is not ideal, as Rails has a convention that implicitly generates paths.

### Solution

Add a `#to_param` method to `User` and `Game` that overrides the expected param to be used in the path.  Now paths can properly be automatically generated with the path helpers (`user_path`, `url_for`, etc.)

### ⚠️ Note!

This will mean that paths for games will no longer be routed through the `/depot/games` path, and instead will be routed simply in `/games`.  I'm sure there is a way to change this without breaking the auto-generated paths (I like these being under `/depot`), but I'll leave that for later. 🙂