### PR TITLE
Rename slug to handle

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -4,7 +4,7 @@ class GamesController < ApplicationController
   end
 
   def show
-    @game = Game.find_by(slug: params[:slug]) or record_not_found
+    @game = Game.find_by(handle: params[:handle]) or record_not_found
     @screenshot_urls = @game.game_screenshots.collect { |s| s.image.url }
     @releases = @game.game_releases
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def show
-    @user = User.find_by(slug: params[:slug]) or record_not_found
+    @user = User.find_by(handle: params[:handle]) or record_not_found
   end
 
   def new
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to user_path(slug: @user.slug)
+      redirect_to user_path(handle: @user)
     else
       render :new
     end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,5 +1,5 @@
 class Game < ApplicationRecord
-  before_validation :generate_slug
+  before_validation :generate_handle
 
   validates :title,
     presence: true,
@@ -12,7 +12,7 @@ class Game < ApplicationRecord
     allow_blank: false,
     string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters] }
 
-  validates :slug,
+  validates :handle,
     presence: true,
     uniqueness: true
 
@@ -23,12 +23,12 @@ class Game < ApplicationRecord
   has_and_belongs_to_many :users
 
   def to_param
-    slug
+    handle
   end
 
   private
 
-    def generate_slug
-      self.slug ||= self.title.parameterize if self.title.present?
+    def generate_handle
+      self.handle ||= self.title.parameterize if self.title.present?
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   before_save { email.downcase! }
-  before_validation :generate_slug
+  before_validation :generate_handle
   validates :username,
     presence: true,
     length: { maximum: 24 },
@@ -16,7 +16,7 @@ class User < ApplicationRecord
     length: { maximum: 255 },
     format: { with: EmailFormat::EMAIL },
     uniqueness: { case_sensitive: false }
-  validates :slug,
+  validates :handle,
     presence: true,
     uniqueness: true
   has_secure_password
@@ -32,12 +32,12 @@ class User < ApplicationRecord
   has_and_belongs_to_many :games
 
   def to_param
-    slug
+    handle
   end
 
   private
 
-    def generate_slug
-      self.slug ||= self.username.parameterize if self.username.present?
+    def generate_handle
+      self.handle ||= self.username.parameterize if self.username.present?
     end
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -31,7 +31,7 @@ RailsAdmin.config do |config|
         :email,
         :updated_at,
         :password_digest,
-        :slug,
+        :handle,
         :website,
         :description
     end
@@ -43,7 +43,7 @@ RailsAdmin.config do |config|
     edit do
       exclude_fields :created_at,
         :password_digest
-      configure :slug do
+      configure :handle do
         read_only true
       end
     end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -55,7 +55,7 @@ RailsAdmin.config do |config|
     edit do
       exclude_fields :created_at,
         :updated_at
-      configure :slug do
+      configure :handle do
         read_only true
       end
     end
@@ -70,6 +70,6 @@ RailsAdmin.config do |config|
   end
 
   def game_release_label_method
-    "#{self.game.slug}-#{self.version_num}"
+    "#{self.game.handle}-#{self.version_num}"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   resources :games, param: :handle, only: [:index, :show]
 
-  resources :users, param: :slug, only: [:show]
+  resources :users, param: :handle, only: [:show]
   get '/signup', to: 'users#new'
   post '/signup', to: 'users#create'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   root 'welcome#index'
 
-  resources :games, param: :slug, only: [:index, :show]
+  resources :games, param: :handle, only: [:index, :show]
 
   resources :users, param: :slug, only: [:show]
   get '/signup', to: 'users#new'

--- a/db/migrate/20170302062847_rename_game_slug_to_handle.rb
+++ b/db/migrate/20170302062847_rename_game_slug_to_handle.rb
@@ -1,0 +1,5 @@
+class RenameGameSlugToHandle < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :games, :slug, :handle
+  end
+end

--- a/db/migrate/20170302063921_rename_user_slug_to_handle.rb
+++ b/db/migrate/20170302063921_rename_user_slug_to_handle.rb
@@ -1,0 +1,5 @@
+class RenameUserSlugToHandle < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :users, :slug, :handle
+  end
+end

--- a/db/migrate/20170302064617_add_index_to_all_handles.rb
+++ b/db/migrate/20170302064617_add_index_to_all_handles.rb
@@ -1,0 +1,6 @@
+class AddIndexToAllHandles < ActiveRecord::Migration[5.0]
+  def change
+    add_index :users, :handle
+    add_index :games, :handle
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302062847) do
+ActiveRecord::Schema.define(version: 20170302063921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 20170302062847) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.string   "password_digest"
-    t.string   "slug"
+    t.string   "handle"
   end
 
   add_foreign_key "game_releases", "games"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302063921) do
+ActiveRecord::Schema.define(version: 20170302064617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20170302063921) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.string   "handle"
+    t.index ["handle"], name: "index_games_on_handle", using: :btree
   end
 
   create_table "games_users", id: false, force: :cascade do |t|
@@ -67,6 +68,7 @@ ActiveRecord::Schema.define(version: 20170302063921) do
     t.datetime "updated_at",      null: false
     t.string   "password_digest"
     t.string   "handle"
+    t.index ["handle"], name: "index_users_on_handle", using: :btree
   end
 
   add_foreign_key "game_releases", "games"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170226084857) do
+ActiveRecord::Schema.define(version: 20170302062847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 20170226084857) do
     t.text     "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
-    t.string   "slug"
+    t.string   "handle"
   end
 
   create_table "games_users", id: false, force: :cascade do |t|

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -1,8 +1,8 @@
 alex_adventures:
   title: Alex Adventures
   description: Join Alex as he explores the vast underbelly of modern society.
-  slug: alex-adventures
+  handle: alex-adventures
 super_biker:
   title: Super Biker
   description: A fast-paced action racer.
-  slug: super-biker
+  handle: super-biker

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,7 +1,7 @@
 markoates:
   username: markoates
   email: marks@example.com
-  slug: markoates
+  handle: markoates
   first_name: Mark
   last_name: Oates
   website: www.example.com

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -54,16 +54,16 @@ class GameTest < ActiveSupport::TestCase
     assert_validates_format_rules expected_validation_rules, Game, :description
   end
 
-  test 'generates a slug on validation' do
+  test 'generates a handle on validation' do
     game.validate
-    assert_equal game.slug, 'game-title'
+    assert_equal game.handle, 'game-title'
   end
 
-  test 'with a slug that already exists, is invalid' do
+  test 'with a handle that already exists, is invalid' do
     game_title_that_already_exists = games(:alex_adventures).title
     game.title = game_title_that_already_exists
     game.validate
-    assert_includes game.errors[:slug], 'has already been taken'
+    assert_includes game.errors[:handle], 'has already been taken'
   end
 
   test 'has many game screenshots' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -115,16 +115,16 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:password], 'can not end with whitespace'
   end
 
-  test 'generates a slug on validation' do
+  test 'generates a handle on validation' do
     user.save
-    assert_equal user.slug, 'mr-test'
+    assert_equal user.handle, 'mr-test'
   end
 
-  test 'with a slug that already exists, is invalid' do
+  test 'with a handle that already exists, is invalid' do
     username_that_already_exists = users(:markoates).username
     user.username = username_that_already_exists
     user.save
-    assert_includes user.errors[:slug], 'has already been taken'
+    assert_includes user.errors[:handle], 'has already been taken'
   end
 
   test 'has and belongs to many games' do


### PR DESCRIPTION
### Problem

The name `slug` is mildly annoying, so I'm going to rename it to `handle`.  It's the part of the path that is used to identify records in the URL:
```
http://www.allegroplanet.com/games/this-last-part-is-the-handle
```

### Solution

Rename it.  Also, this PR adds an index on the `handle`s for `User` and `Game` so lookup will be faster.