### PR TITLE
Allow newlines in textareas

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -5,12 +5,12 @@ class Game < ApplicationRecord
     presence: true,
     uniqueness: true,
     allow_blank: false,
-    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters] }
+    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :only_printable_characters] }
 
   validates :description,
     presence: true,
     allow_blank: false,
-    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters] }
+    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :only_printable_characters] }
 
   validates :handle,
     presence: true,

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -10,7 +10,7 @@ class Game < ApplicationRecord
   validates :description,
     presence: true,
     allow_blank: false,
-    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :only_printable_characters] }
+    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :only_printable_characters_and_newlines] }
 
   validates :handle,
     presence: true,

--- a/app/models/game_release.rb
+++ b/app/models/game_release.rb
@@ -3,7 +3,7 @@ class GameRelease < ApplicationRecord
     presence: true,
     uniqueness: { scope: :game, message: 'already exists' },
     allow_blank: false,
-    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters] }
+    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace, :only_printable_characters] }
 
   belongs_to :game
 

--- a/app/validators/string_format_validator.rb
+++ b/app/validators/string_format_validator.rb
@@ -2,7 +2,7 @@ class StringFormatValidator < ActiveModel::EachValidator
   VALIDATIONS = {
     starts_with_non_whitespace: { regex: /\A\S/, message: "can't start with whitespace", },
     ends_with_non_whitespace: { regex: /\S\z/, message: "can't end with whitespace", },
-    only_printable_characters: { regex: /\A[[:print:]]*\z/, message: 'can only contain printable characters', }
+    only_printable_characters: { regex: /\A[[:print:]]*\z/, message: 'can only contain printable characters', },
   }
 
   def validate_each(record, attribute, value)

--- a/app/validators/string_format_validator.rb
+++ b/app/validators/string_format_validator.rb
@@ -2,7 +2,7 @@ class StringFormatValidator < ActiveModel::EachValidator
   VALIDATIONS = {
     starts_with_non_whitespace: { regex: /\A\S/, message: "can't start with whitespace", },
     ends_with_non_whitespace: { regex: /\S\z/, message: "can't end with whitespace", },
-    has_only_printable_characters: { regex: /\A[[:print:]]*\z/, message: 'can only contain printable characters', }
+    only_printable_characters: { regex: /\A[[:print:]]*\z/, message: 'can only contain printable characters', }
   }
 
   def validate_each(record, attribute, value)

--- a/app/validators/string_format_validator.rb
+++ b/app/validators/string_format_validator.rb
@@ -3,6 +3,7 @@ class StringFormatValidator < ActiveModel::EachValidator
     starts_with_non_whitespace: { regex: /\A\S/, message: "can't start with whitespace", },
     ends_with_non_whitespace: { regex: /\S\z/, message: "can't end with whitespace", },
     only_printable_characters: { regex: /\A[[:print:]]*\z/, message: 'can only contain printable characters', },
+    only_printable_characters_and_newlines: { regex: /\A[[:print:]\n]*\z/, message: 'can only contain printable characters and newlines', },
   }
 
   def validate_each(record, attribute, value)

--- a/test/models/game_release_test.rb
+++ b/test/models/game_release_test.rb
@@ -39,7 +39,7 @@ class GameReleaseTest < ActiveSupport::TestCase
   end
 
   test 'version_num is formatted with the expected rules' do
-    expected_validation_rules = [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters]
+    expected_validation_rules = [:starts_with_non_whitespace, :ends_with_non_whitespace, :only_printable_characters]
     assert_validates_format_rules expected_validation_rules, GameRelease, :version_num
   end
 

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -33,7 +33,7 @@ class GameTest < ActiveSupport::TestCase
   end
 
   test 'title is formatted with the expected rules' do
-    expected_validation_rules = [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters]
+    expected_validation_rules = [:starts_with_non_whitespace, :ends_with_non_whitespace, :only_printable_characters]
     assert_validates_format_rules expected_validation_rules, Game, :title
   end
 
@@ -50,7 +50,7 @@ class GameTest < ActiveSupport::TestCase
   end
 
   test 'description is formatted with the expected rules' do
-    expected_validation_rules = [:starts_with_non_whitespace, :ends_with_non_whitespace, :has_only_printable_characters]
+    expected_validation_rules = [:starts_with_non_whitespace, :ends_with_non_whitespace, :only_printable_characters]
     assert_validates_format_rules expected_validation_rules, Game, :description
   end
 

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -50,7 +50,7 @@ class GameTest < ActiveSupport::TestCase
   end
 
   test 'description is formatted with the expected rules' do
-    expected_validation_rules = [:starts_with_non_whitespace, :ends_with_non_whitespace, :only_printable_characters]
+    expected_validation_rules = [:starts_with_non_whitespace, :ends_with_non_whitespace, :only_printable_characters_and_newlines]
     assert_validates_format_rules expected_validation_rules, Game, :description
   end
 

--- a/test/validators/string_format_validator_test.rb
+++ b/test/validators/string_format_validator_test.rb
@@ -9,6 +9,14 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
     end
   end
 
+  def ascii_characters
+    @ascii_characters ||= (0..255).to_a.map(&:chr)
+  end
+
+  def printable_characters
+    @printable_characters ||= (32..126).to_a.map(&:chr)
+  end
+
   def teardown
     FooClass.clear_validators!
   end
@@ -18,6 +26,7 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
       :starts_with_non_whitespace,
       :ends_with_non_whitespace,
       :only_printable_characters,
+      :only_printable_characters_and_newlines,
     ]
     existing_rules = StringFormatValidator::VALIDATIONS.keys
     assert_equal expected_rules, existing_rules
@@ -42,5 +51,24 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
     foo = FooClass.new("\x0A")
     foo.validate
     assert_includes foo.errors[:bar], 'can only contain printable characters'
+  end
+
+  test ':only_printable_characters_and_newlines rule checks that the value can only contain printable characters and newlines' do
+    FooClass.validates(:bar, string_format: { rules: [:only_printable_characters_and_newlines] })
+
+    allowed_characters = printable_characters.push("\n")
+
+    allowed_characters.each do |char|
+      foo = FooClass.new("#{char}")
+      foo.validate
+      refute_includes foo.errors[:bar], 'can only contain printable characters and newlines'
+    end
+
+    disallowed_characters = ascii_characters - allowed_characters
+    disallowed_characters.each do |char|
+      foo = FooClass.new(char)
+      foo.validate
+      assert_includes foo.errors[:bar], 'can only contain printable characters and newlines', foo.bar
+    end
   end
 end

--- a/test/validators/string_format_validator_test.rb
+++ b/test/validators/string_format_validator_test.rb
@@ -9,6 +9,10 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
     end
   end
 
+  def teardown
+    FooClass.clear_validators!
+  end
+
   test 'contains the expected set of validation rules' do
     expected_rules = [
       :starts_with_non_whitespace,

--- a/test/validators/string_format_validator_test.rb
+++ b/test/validators/string_format_validator_test.rb
@@ -13,7 +13,7 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
     expected_rules = [
       :starts_with_non_whitespace,
       :ends_with_non_whitespace,
-      :has_only_printable_characters
+      :only_printable_characters,
     ]
     existing_rules = StringFormatValidator::VALIDATIONS.keys
     assert_equal expected_rules, existing_rules
@@ -33,8 +33,8 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
     assert_includes foo.errors[:bar], "can't end with whitespace"
   end
 
-  test ':has_only_printable_characters rule checks that the value can only contain printable characters' do
-    FooClass.validates(:bar, string_format: { rules: [:has_only_printable_characters] })
+  test ':only_printable_characters rule checks that the value can only contain printable characters' do
+    FooClass.validates(:bar, string_format: { rules: [:only_printable_characters] })
     foo = FooClass.new("\x0A")
     foo.validate
     assert_includes foo.errors[:bar], 'can only contain printable characters'


### PR DESCRIPTION
## Problem

When creating a `Game`, you [can not have newline characters in the description](https://cloud.githubusercontent.com/assets/772949/23580834/089b3070-00d7-11e7-9272-a0d56a215142.png).  Currently, the field only allows [printable ascii characters](http://web.itu.edu.tr/sgunduz/courses/mikroisl/ascii.html).

## Solution

Create a new format in `StringFormatValidator` that allows printable characters and new lines.

## Also

In `StringFormatValidator`, `has_only_printable_characters` has been renamed to `only_printable_characters`.