### PR TITLE
Remove Legacy String Validation

### DIFF
--- a/app/models/concerns/email_format.rb
+++ b/app/models/concerns/email_format.rb
@@ -1,3 +1,0 @@
-module EmailFormat
-  EMAIL = /\A[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\z/i
-end

--- a/app/models/concerns/string_format.rb
+++ b/app/models/concerns/string_format.rb
@@ -1,7 +1,0 @@
-module StringFormat
-  STARTS_WITH_NON_WHITESPACE = /\A\S/
-  ENDS_WITH_NON_WHITESPACE = /\S\z/
-  ONLY_PRINTABLE_CHARACTERS = /\A[[:print:]]*\z/
-  EIGHT_OR_MORE_CHARACTERS = /\A.{8,}\z/
-  CONTAINS_A_DIGIT = /\d/
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,11 +22,8 @@ class User < ApplicationRecord
     uniqueness: true
 
   validates :password,
-    length: { minimum: 8 }
-  validates :password, format: { with: StringFormat::STARTS_WITH_NON_WHITESPACE,
-                                 message: 'can not start with whitespace' }
-  validates :password, format: { with: StringFormat::ENDS_WITH_NON_WHITESPACE,
-                                 message: 'can not end with whitespace' }
+    length: { minimum: 8 },
+    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace] }
 
   has_and_belongs_to_many :games
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,8 +21,8 @@ class User < ApplicationRecord
     presence: true,
     uniqueness: true
 
-  validates :password, format: { with: StringFormat::EIGHT_OR_MORE_CHARACTERS,
-                                 message: 'must have 8 or more characters' }
+  validates :password,
+    length: { minimum: 8 }
   validates :password, format: { with: StringFormat::STARTS_WITH_NON_WHITESPACE,
                                  message: 'can not start with whitespace' }
   validates :password, format: { with: StringFormat::ENDS_WITH_NON_WHITESPACE,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
+  has_secure_password
+
   before_save { email.downcase! }
+
   before_validation :generate_handle
+
   validates :username,
     presence: true,
     length: { maximum: 24 },
@@ -11,15 +15,17 @@ class User < ApplicationRecord
                                  message: 'can not start with whitespace' }
   validates :username, format: { with: StringFormat::ENDS_WITH_NON_WHITESPACE,
                                  message: 'can not end with whitespace' }
+
   validates :email,
     presence: true,
     length: { maximum: 255 },
     format: { with: EmailFormat::EMAIL },
     uniqueness: { case_sensitive: false }
+
   validates :handle,
     presence: true,
     uniqueness: true
-  has_secure_password
+
   validates :password, format: { with: StringFormat::EIGHT_OR_MORE_CHARACTERS,
                                  message: 'must have 8 or more characters' }
   validates :password, format: { with: StringFormat::CONTAINS_A_DIGIT,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   validates :email,
     presence: true,
     length: { maximum: 255 },
-    format: { with: EmailFormat::EMAIL },
+    string_format: { rules: [:email] },
     uniqueness: { case_sensitive: false }
 
   validates :handle,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
 
   validates :password,
     length: { minimum: 8 },
-    string_format: { rules: [:starts_with_non_whitespace, :ends_with_non_whitespace] }
+    string_format: { rules: [:only_printable_characters, :starts_with_non_whitespace, :ends_with_non_whitespace] }
 
   has_and_belongs_to_many :games
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,8 +23,6 @@ class User < ApplicationRecord
 
   validates :password, format: { with: StringFormat::EIGHT_OR_MORE_CHARACTERS,
                                  message: 'must have 8 or more characters' }
-  validates :password, format: { with: StringFormat::CONTAINS_A_DIGIT,
-                                 message: 'must have at least one digit' }
   validates :password, format: { with: StringFormat::STARTS_WITH_NON_WHITESPACE,
                                  message: 'can not start with whitespace' }
   validates :password, format: { with: StringFormat::ENDS_WITH_NON_WHITESPACE,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,13 +8,8 @@ class User < ApplicationRecord
   validates :username,
     presence: true,
     length: { maximum: 24 },
-    uniqueness: { case_sensitive: false }
-  validates :username, format: { with: StringFormat::ONLY_PRINTABLE_CHARACTERS,
-                                 message: 'can only contain printable characters' }
-  validates :username, format: { with: StringFormat::STARTS_WITH_NON_WHITESPACE,
-                                 message: 'can not start with whitespace' }
-  validates :username, format: { with: StringFormat::ENDS_WITH_NON_WHITESPACE,
-                                 message: 'can not end with whitespace' }
+    uniqueness: { case_sensitive: false },
+    string_format: { rules: [:only_printable_characters, :starts_with_non_whitespace, :ends_with_non_whitespace] }
 
   validates :email,
     presence: true,

--- a/app/validators/string_format_validator.rb
+++ b/app/validators/string_format_validator.rb
@@ -4,6 +4,7 @@ class StringFormatValidator < ActiveModel::EachValidator
     ends_with_non_whitespace: { regex: /\S\z/, message: "can't end with whitespace", },
     only_printable_characters: { regex: /\A[[:print:]]*\z/, message: 'can only contain printable characters', },
     only_printable_characters_and_newlines: { regex: /\A[[:print:]\n]*\z/, message: 'can only contain printable characters and newlines', },
+    email: { regex: /\A[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\z/i, message: 'must be a valid email' },
   }
 
   def validate_each(record, attribute, value)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -21,58 +21,58 @@ class UserTest < ActiveSupport::TestCase
 
   test 'username must be present' do
     user.username = ''
-    user.save
+    user.validate
     assert_includes user.errors[:username], "can't be blank"
   end
 
   test 'username can not be longer than 24 characters' do
     username_too_long = 'a' * 25
     user.username = username_too_long
-    user.save
+    user.validate
     assert_includes user.errors[:username], 'is too long (maximum is 24 characters)'
   end
 
   test 'username must be unique' do
     already_existing_username = users(:markoates).username
     user.username = already_existing_username
-    user.save
+    user.validate
     assert_includes user.errors[:username], 'has already been taken'
   end
 
   test 'username must contain only printable characters' do
     user.username = "\x0A"
-    user.save
+    user.validate
     assert_includes user.errors[:username], 'can only contain printable characters'
   end
 
   test 'username can not end in whitespace' do
     user.username = 'endsinwhitespace '
-    user.save
+    user.validate
     assert_includes user.errors[:username], "can't end with whitespace"
   end
 
   test 'username can not start with whitespace' do
     user.username = ' startswithwhitespace'
-    user.save
+    user.validate
     assert_includes user.errors[:username], "can't start with whitespace"
   end
 
   test 'email must be present' do
     user.email = ''
-    user.save
+    user.validate
     assert_includes user.errors[:email], "can't be blank"
   end
 
   test 'email must be valid' do
     user.email = 'an_invalid%^&*email'
-    user.save
+    user.validate
     assert_includes user.errors[:email], 'must be a valid email'
   end
 
   test 'email must be unique' do
     already_existing_email = users(:markoates).email
     user.email = already_existing_email
-    user.save
+    user.validate
     assert_includes user.errors[:email], 'has already been taken'
   end
 
@@ -86,37 +86,37 @@ class UserTest < ActiveSupport::TestCase
 
   test 'with a password less than 8 characters, is invalid' do
     user.password = 'pw2shrt'
-    user.save
+    user.validate
     assert_includes user.errors[:password], 'is too short (minimum is 8 characters)'
   end
 
   test 'with a password that starts with whitespace, is invalid' do
     user.password = ' startwithspace'
-    user.save
+    user.validate
     assert_includes user.errors[:password], "can't start with whitespace"
   end
 
   test 'with a password that ends with whitespace, is invalid' do
     user.password = 'endswithspace '
-    user.save
+    user.validate
     assert_includes user.errors[:password], "can't end with whitespace"
   end
 
   test 'with a password that contains non-printable characters, is invalid' do
     user.password = "\0x07"
-    user.save
+    user.validate
     assert_includes user.errors[:password], 'can only contain printable characters'
   end
 
   test 'generates a handle on validation' do
-    user.save
+    user.validate
     assert_equal user.handle, 'mr-test'
   end
 
   test 'with a handle that already exists, is invalid' do
     username_that_already_exists = users(:markoates).username
     user.username = username_that_already_exists
-    user.save
+    user.validate
     assert_includes user.errors[:handle], 'has already been taken'
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -93,13 +93,13 @@ class UserTest < ActiveSupport::TestCase
   test 'with a password that starts with whitespace, is invalid' do
     user.password = ' startwithspace'
     user.save
-    assert_includes user.errors[:password], 'can not start with whitespace'
+    assert_includes user.errors[:password], "can't start with whitespace"
   end
 
   test 'with a password that ends with whitespace, is invalid' do
     user.password = 'endswithspace '
     user.save
-    assert_includes user.errors[:password], 'can not end with whitespace'
+    assert_includes user.errors[:password], "can't end with whitespace"
   end
 
   test 'generates a handle on validation' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -87,7 +87,7 @@ class UserTest < ActiveSupport::TestCase
   test 'with a password less than 8 characters, is invalid' do
     user.password = 'pw2shrt'
     user.save
-    assert_includes user.errors[:password], 'must have 8 or more characters'
+    assert_includes user.errors[:password], 'is too short (minimum is 8 characters)'
   end
 
   test 'with a password that starts with whitespace, is invalid' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -102,6 +102,12 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:password], "can't end with whitespace"
   end
 
+  test 'with a password that contains non-printable characters, is invalid' do
+    user.password = "\0x07"
+    user.save
+    assert_includes user.errors[:password], 'can only contain printable characters'
+  end
+
   test 'generates a handle on validation' do
     user.save
     assert_equal user.handle, 'mr-test'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -63,17 +63,10 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:email], "can't be blank"
   end
 
-  test 'email must be less that 255 characters' do
-    too_long_email = 'a' * 256
-    user.email = too_long_email
-    user.save
-    assert_includes user.errors[:email], 'is invalid'
-  end
-
   test 'email must be valid' do
     user.email = 'an_invalid%^&*email'
     user.save
-    assert_includes user.errors[:email], 'is invalid'
+    assert_includes user.errors[:email], 'must be a valid email'
   end
 
   test 'email must be unique' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -48,13 +48,13 @@ class UserTest < ActiveSupport::TestCase
   test 'username can not end in whitespace' do
     user.username = 'endsinwhitespace '
     user.save
-    assert_includes user.errors[:username], 'can not end with whitespace'
+    assert_includes user.errors[:username], "can't end with whitespace"
   end
 
   test 'username can not start with whitespace' do
     user.username = ' startswithwhitespace'
     user.save
-    assert_includes user.errors[:username], 'can not start with whitespace'
+    assert_includes user.errors[:username], "can't start with whitespace"
   end
 
   test 'email must be present' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -90,12 +90,6 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:password], 'must have 8 or more characters'
   end
 
-  test 'with a password that does not contain at least one digit, is invalid' do
-    user.password = 'nodigits'
-    user.save
-    assert_includes user.errors[:password], 'must have at least one digit'
-  end
-
   test 'with a password that starts with whitespace, is invalid' do
     user.password = ' startwithspace'
     user.save

--- a/test/validators/string_format_validator_test.rb
+++ b/test/validators/string_format_validator_test.rb
@@ -27,6 +27,7 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
       :ends_with_non_whitespace,
       :only_printable_characters,
       :only_printable_characters_and_newlines,
+      :email,
     ]
     existing_rules = StringFormatValidator::VALIDATIONS.keys
     assert_equal expected_rules, existing_rules
@@ -70,5 +71,17 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
       foo.validate
       assert_includes foo.errors[:bar], 'can only contain printable characters and newlines', foo.bar
     end
+  end
+
+  test ':email rule checks that the value is a valid email format' do
+    FooClass.validates(:bar, string_format: { rules: [:email] })
+
+    foo = FooClass.new("not-a-valid-email")
+    foo.validate
+    assert_includes foo.errors[:bar], 'must be a valid email'
+
+    foo = FooClass.new("valid.email@gmail.com")
+    foo.validate
+    refute_includes foo.errors[:bar], 'must be a valid email'
   end
 end


### PR DESCRIPTION
## Problem

In the beginning, validations on the models were originally created using an `EmailFormat` concern and a `StringFormat` concern with regexes and messages.  Later, a custom validator, `StringFormatValidator`, was used that generates better error messages and is more developer-friendly.

However, there is still some usage of the older `EmailFormat` and `StringFormat` concerns.

## Solution

Remove the `EmailFormat` and `StringFormat` and replace them with the new `StringFormatValidator`.

## Also

Two tangentially related things have been added/changed:
- The "at least one digit" requirement has been removed from `password`
- An new `:only_printable_characters` requirement has been added to `password`