### PR TITLE
Allow carriage return "\r" character in text fields

### DIFF
--- a/app/validators/string_format_validator.rb
+++ b/app/validators/string_format_validator.rb
@@ -3,7 +3,7 @@ class StringFormatValidator < ActiveModel::EachValidator
     starts_with_non_whitespace: { regex: /\A\S/, message: "can't start with whitespace", },
     ends_with_non_whitespace: { regex: /\S\z/, message: "can't end with whitespace", },
     only_printable_characters: { regex: /\A[[:print:]]*\z/, message: 'can only contain printable characters', },
-    only_printable_characters_and_newlines: { regex: /\A[[:print:]\n]*\z/, message: 'can only contain printable characters and newlines', },
+    only_printable_characters_and_newlines: { regex: /\A[[:print:]\r\n]*\z/, message: 'can only contain printable characters and newlines', },
     email: { regex: /\A[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\z/i, message: 'must be a valid email' },
   }
 

--- a/test/validators/string_format_validator_test.rb
+++ b/test/validators/string_format_validator_test.rb
@@ -57,7 +57,7 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
   test ':only_printable_characters_and_newlines rule checks that the value can only contain printable characters and newlines' do
     FooClass.validates(:bar, string_format: { rules: [:only_printable_characters_and_newlines] })
 
-    allowed_characters = printable_characters.push("\n")
+    allowed_characters = printable_characters + ["\r", "\n"]
 
     allowed_characters.each do |char|
       foo = FooClass.new("#{char}")


### PR DESCRIPTION
## Problem

Some editors (like rails admin) will return text fields with `\r\n` as newlines.  This is a problem since the `\r` character does not pass validation:

![stuff is winning - game allegro planet admin 2017-03-04 13-50-46](https://cloud.githubusercontent.com/assets/772949/23581445/f45ecf1c-00e1-11e7-9cd9-b235d1ea1ab3.png)

## Solution

Rather than sanitize the input, allow the carriage return `\r`character to qualify as a newline character.