### PR TITLE
Fix Username Format

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   validates :username,
     presence: true,
-    length: { maximum: 24 },
+    length: { maximum: 24, minimum: 2 },
     uniqueness: { case_sensitive: false },
     string_format: { rules: [:only_printable_characters, :starts_with_non_whitespace, :ends_with_non_whitespace] }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
     presence: true,
     length: { maximum: 24, minimum: 2 },
     uniqueness: { case_sensitive: false },
-    string_format: { rules: [:only_printable_characters, :starts_with_non_whitespace, :ends_with_non_whitespace] }
+    string_format: { rules: [:username_characters, :starts_with_non_whitespace, :ends_with_non_whitespace] }
 
   validates :email,
     presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
     presence: true,
     length: { maximum: 24, minimum: 2 },
     uniqueness: { case_sensitive: false },
-    string_format: { rules: [:username_characters, :starts_with_non_whitespace, :ends_with_non_whitespace] }
+    string_format: { rules: [:username_characters, :starts_with_non_whitespace, :ends_with_non_whitespace, :at_least_one_alphanumeric_character] }
 
   validates :email,
     presence: true,

--- a/app/validators/string_format_validator.rb
+++ b/app/validators/string_format_validator.rb
@@ -6,6 +6,7 @@ class StringFormatValidator < ActiveModel::EachValidator
     only_printable_characters_and_newlines: { regex: /\A[[:print:]\r\n]*\z/, message: 'can only contain printable characters and newlines', },
     email: { regex: /\A[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\z/i, message: 'must be a valid email' },
     username_characters: { regex: /\A[[:alnum:] \._\-~]*\z/, message: "can only contain alphanumeric, '-', '_', space, '.', and '~' characters" },
+    at_least_one_alphanumeric_character: { regex: /[[:alnum:]]+/, message: "must contain at least one alphanumeric character" },
   }
 
   def validate_each(record, attribute, value)

--- a/app/validators/string_format_validator.rb
+++ b/app/validators/string_format_validator.rb
@@ -5,6 +5,7 @@ class StringFormatValidator < ActiveModel::EachValidator
     only_printable_characters: { regex: /\A[[:print:]]*\z/, message: 'can only contain printable characters', },
     only_printable_characters_and_newlines: { regex: /\A[[:print:]\r\n]*\z/, message: 'can only contain printable characters and newlines', },
     email: { regex: /\A[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\z/i, message: 'must be a valid email' },
+    username_characters: { regex: /\A[[:alnum:] \._\-~]*\z/, message: "can only contain alphanumeric, '-', '_', space, '.', and '~' characters" },
   }
 
   def validate_each(record, attribute, value)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -32,6 +32,13 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:username], 'is too long (maximum is 24 characters)'
   end
 
+  test 'username must be at least 2 characters' do
+    username_too_short = 'B'
+    user.username = username_too_short
+    user.validate
+    assert_includes user.errors[:username], 'is too short (minimum is 2 characters)'
+  end
+
   test 'username must be unique' do
     already_existing_username = users(:markoates).username
     user.username = already_existing_username

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -52,6 +52,12 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:username], "can only contain alphanumeric, '-', '_', space, '.', and '~' characters"
   end
 
+  test 'username must have at least one alphanumeric character' do
+    user.username = "_-~"
+    user.validate
+    assert_includes user.errors[:username], 'must contain at least one alphanumeric character'
+  end
+
   test 'username can not end in whitespace' do
     user.username = 'endsinwhitespace '
     user.validate

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -46,10 +46,10 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:username], 'has already been taken'
   end
 
-  test 'username must contain only printable characters' do
+  test 'username must contain only the allowed characters' do
     user.username = "\x0A"
     user.validate
-    assert_includes user.errors[:username], 'can only contain printable characters'
+    assert_includes user.errors[:username], "contain only alphanumeric, '-', '_', space, '.', and '~' characters"
   end
 
   test 'username can not end in whitespace' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -49,7 +49,7 @@ class UserTest < ActiveSupport::TestCase
   test 'username must contain only the allowed characters' do
     user.username = "\x0A"
     user.validate
-    assert_includes user.errors[:username], "contain only alphanumeric, '-', '_', space, '.', and '~' characters"
+    assert_includes user.errors[:username], "can only contain alphanumeric, '-', '_', space, '.', and '~' characters"
   end
 
   test 'username can not end in whitespace' do

--- a/test/validators/string_format_validator_test.rb
+++ b/test/validators/string_format_validator_test.rb
@@ -28,6 +28,7 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
       :only_printable_characters,
       :only_printable_characters_and_newlines,
       :email,
+      :username_characters,
     ]
     existing_rules = StringFormatValidator::VALIDATIONS.keys
     assert_equal expected_rules, existing_rules
@@ -83,5 +84,24 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
     foo = FooClass.new("valid.email@gmail.com")
     foo.validate
     refute_includes foo.errors[:bar], 'must be a valid email'
+  end
+
+  test ':username_characters rule checks that the value can only contain alphanum, space, tilde, underscore, hyphen, and period characters' do
+    FooClass.validates(:bar, string_format: { rules: [:username_characters] })
+
+    allowed_characters = ('a'..'z').to_a + ('0'..'9').to_a + ('A'..'Z').to_a + [' ', '-', '~', '_', '.']
+
+    allowed_characters.each do |char|
+      foo = FooClass.new("#{char}")
+      foo.validate
+      refute_includes foo.errors[:bar], "can only contain alphanumeric, '-', '_', space, '.', and '~' characters"
+    end
+
+    disallowed_characters = ascii_characters - allowed_characters
+    disallowed_characters.each do |char|
+      foo = FooClass.new(char)
+      foo.validate
+      assert_includes foo.errors[:bar], "can only contain alphanumeric, '-', '_', space, '.', and '~' characters"
+    end
   end
 end

--- a/test/validators/string_format_validator_test.rb
+++ b/test/validators/string_format_validator_test.rb
@@ -29,6 +29,7 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
       :only_printable_characters_and_newlines,
       :email,
       :username_characters,
+      :at_least_one_alphanumeric_character,
     ]
     existing_rules = StringFormatValidator::VALIDATIONS.keys
     assert_equal expected_rules, existing_rules
@@ -103,5 +104,19 @@ class StringFormatValidatorTest < ActiveSupport::TestCase
       foo.validate
       assert_includes foo.errors[:bar], "can only contain alphanumeric, '-', '_', space, '.', and '~' characters"
     end
+  end
+
+  test ':at_least_one_alphanumeric_character must contain at least one character in [0-9a-zA-Z]' do
+    FooClass.validates(:bar, string_format: { rules: [:at_least_one_alphanumeric_character] })
+
+    allowed_characters = ('a'..'z').to_a + ('0'..'9').to_a + ('A'..'Z').to_a
+
+    foo = FooClass.new("-_~")
+    foo.validate
+    assert_includes foo.errors[:bar], "must contain at least one alphanumeric character"
+
+    foo = FooClass.new("-A~")
+    foo.validate
+    refute_includes foo.errors[:bar], "must contain at least one alphanumeric character"
   end
 end


### PR DESCRIPTION
## Problem

Username formats are not very robust and allow for some weird names (e.g. `^&*]{`, or `_-~`).

## Solution

Reduce the scope of characters and format that is allowed for a username by creating a new validation rule `:username_characters`.  Also an `:at_least_one_alphanumeric_character` rule was added as well.

[See this issue for a list of format requirements](https://github.com/allegroplanet/allegro-planet/issues/26).

/ fixes https://github.com/allegroplanet/allegro-planet/issues/26