### PR TITLE
Cleanup s3 screenshot urls

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -6,7 +6,7 @@ class GamesController < ApplicationController
   def show
     @game = Game.find_by(handle: params[:handle]) or record_not_found
     @description = MarkdownConverter.new(@game.description).html
-    @screenshot_urls = @game.game_screenshots.collect { |s| s.image.url }
+    @screenshot_urls = @game.game_screenshots.collect { |s| s.public_url }
     @releases = @game.game_releases.collect { |r| GameReleaseDecorator.new(r) }
   end
 end

--- a/app/decorators/game_release_decorator.rb
+++ b/app/decorators/game_release_decorator.rb
@@ -8,7 +8,7 @@ class GameReleaseDecorator
   end
 
   def game_files
-    @game_files ||= @game_release.game_files.each.collect do |f| { category: f.category, url: f.public_url }
+    @game_files ||= @game_release.game_files.each.collect do |f| { category: f.category, public_url: f.public_url }
     end
   end
 

--- a/app/decorators/game_release_decorator.rb
+++ b/app/decorators/game_release_decorator.rb
@@ -8,11 +8,7 @@ class GameReleaseDecorator
   end
 
   def game_files
-    @game_files ||= @game_release.game_files.each.collect do |game_file|
-      {
-        category: game_file.category,
-        url:      game_file.public_url,
-      }
+    @game_files ||= @game_release.game_files.each.collect do |f| { category: f.category, url: f.public_url }
     end
   end
 

--- a/app/decorators/game_release_decorator.rb
+++ b/app/decorators/game_release_decorator.rb
@@ -11,7 +11,7 @@ class GameReleaseDecorator
     @game_files ||= @game_release.game_files.each.collect do |game_file|
       {
         category: game_file.category,
-        url:      "https://#{Figaro.env.aws_allegro_planet_bucket}.s3.amazonaws.com/#{game_file.file.path}"
+        url:      game_file.public_url,
       }
     end
   end

--- a/app/decorators/game_release_decorator.rb
+++ b/app/decorators/game_release_decorator.rb
@@ -8,10 +8,10 @@ class GameReleaseDecorator
   end
 
   def game_files
-    @game_files ||= @game_release.game_files.each.collect do |release|
+    @game_files ||= @game_release.game_files.each.collect do |game_file|
       {
-        category: release.category,
-        url:      "https://#{Figaro.env.aws_allegro_planet_bucket}.s3.amazonaws.com/#{release.file.path}"
+        category: game_file.category,
+        url:      "https://#{Figaro.env.aws_allegro_planet_bucket}.s3.amazonaws.com/#{game_file.file.path}"
       }
     end
   end

--- a/app/models/game_file.rb
+++ b/app/models/game_file.rb
@@ -9,4 +9,8 @@ class GameFile < ApplicationRecord
     inclusion: { in: GAME_FILE_CATEGORIES, message: INCLUSION_MESSAGE }
 
   belongs_to :game_release
+
+  def public_url
+    "https://#{Figaro.env.aws_allegro_planet_bucket}.s3.amazonaws.com/#{file.path}"
+  end
 end

--- a/app/models/game_screenshot.rb
+++ b/app/models/game_screenshot.rb
@@ -2,4 +2,8 @@ class GameScreenshot < ApplicationRecord
   mount_uploader :image, GameScreenshotUploader
 
   belongs_to :game
+
+  def public_url
+    "https://#{Figaro.env.aws_allegro_planet_bucket}.s3.amazonaws.com/#{image.path}"
+  end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -19,7 +19,7 @@
     <div>
       <ul>
       <% release.game_files.each do |game_file| %>
-        <li><%= link_to(game_file[:category], game_file[:url]) %></li>
+        <li><%= link_to(game_file[:category], game_file[:public_url]) %></li>
       <% end %>
       </ul>
     </div>

--- a/test/decorators/game_release_decorator_test.rb
+++ b/test/decorators/game_release_decorator_test.rb
@@ -13,8 +13,8 @@ class GameReleaseDecoratorTest < ActiveSupport::TestCase
   test '#game_files returns the files associated with the game release' do
     returned_game_files = decorated_release(:alex_release_v1).game_files
     expected_game_files = [
-      { category: "Win binary", url: 'https://test-buhkit.s3.amazonaws.com/game-files/alex-v1-win32.zip' },
-      { category: "MacOS binary", url: 'https://test-buhkit.s3.amazonaws.com/game-files/alex-v1-macos.zip' },
+      { category: "Win binary", public_url: 'https://test-buhkit.s3.amazonaws.com/game-files/alex-v1-win32.zip' },
+      { category: "MacOS binary", public_url: 'https://test-buhkit.s3.amazonaws.com/game-files/alex-v1-macos.zip' },
     ]
 
     assert_equal expected_game_files, returned_game_files

--- a/test/fixtures/game_screenshots.yml
+++ b/test/fixtures/game_screenshots.yml
@@ -1,0 +1,3 @@
+alex_screenshot_1:
+  game: alex_adventures
+  image: title-screen-screenshot.jpg

--- a/test/models/game_file_test.rb
+++ b/test/models/game_file_test.rb
@@ -46,4 +46,10 @@ class GameFileTest < ActiveSupport::TestCase
   test 'has the expected category error message' do
     assert_equal GameFile::INCLUSION_MESSAGE, "must be one of #{GameFile::GAME_FILE_CATEGORIES}"
   end
+
+  test '#public_url returns the expected url' do
+    returned_url = game_files(:win_32_binary).public_url
+    expected_url = "https://test-buhkit.s3.amazonaws.com/game-files/alex-v1-win32.zip"
+    assert_equal expected_url, returned_url
+  end
 end

--- a/test/models/game_screenshot_test.rb
+++ b/test/models/game_screenshot_test.rb
@@ -9,4 +9,10 @@ class GameScreenshotTest < ActiveSupport::TestCase
     associations = game_screenshot_associations(:belongs_to, :game)
     assert associations.one?
   end
+
+  test '#public_url returns the expected url' do
+    returned_url = game_screenshots(:alex_screenshot_1).public_url
+    expected_url = "https://test-buhkit.s3.amazonaws.com/screenshots/title-screen-screenshot.jpg"
+    assert_equal expected_url, returned_url
+  end
 end


### PR DESCRIPTION
### Problem

For some reason, CarrierWave and S3 like to generate really nasty URLs that look like this:

```
https://allegro-planet.s3.amazonaws.com/screenshots/krampus_shot_3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIB5BMVW4AB8A%9201456704%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20170305T055242Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=f4aeab5df7dba2a875b4c77ae8b99a9a32cc17ae9bbbd6ca1bc0
```

### Solution

Clean up the URLs by adding a `#public_url` method directly on the models for `GameFile` and `GameScreenshot`.  Now URLs would look like this:

```
https://allegro-planet.s3.amazonaws.com/screenshots/krampus_shot_3.png
```