### PR TITLE
Allow MarkdownConverter to Work Even When Given Empty Values

### DIFF
--- a/app/converters/markdown_converter.rb
+++ b/app/converters/markdown_converter.rb
@@ -6,7 +6,7 @@ class MarkdownConverter
   end
 
   def html
-    @html ||= converter.render(@markdown).html_safe
+    @html ||= @markdown.present? ? converter.render(@markdown).html_safe : ''
   end
 
   private

--- a/test/converters/markdown_converter_test.rb
+++ b/test/converters/markdown_converter_test.rb
@@ -8,6 +8,15 @@ class MarkdownConverterTest < ActiveSupport::TestCase
     assert_equal expected_html, returned_html
   end
 
+  test "#html will return an empty string if source text isn't present" do
+    blank_values = ["", " ", nil, []]
+
+    blank_values.each do |blank_value|
+      returned_html = MarkdownConverter.new(blank_value).html
+      assert_equal '', returned_html
+    end
+  end
+
   test '#html automatically converts URLs into clickable links' do
     returned_html = MarkdownConverter.new("link: https://www.allegroplanet.com").html
     expected_html = "<p>link: <a href=\"https://www.allegroplanet.com\">https://www.allegroplanet.com</a></p>\n"


### PR DESCRIPTION
### Problem

Whenever the `MarkdownConverter` attempts to render content of a `nul` value, it raises an exception and prevents the page from rendering.

### Solution

Update `MarkdownConverter` to render "blank" arguments into an empty string.