### PR TITLE
Fix User Password Validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,8 @@ class User < ApplicationRecord
 
   validates :password,
     length: { minimum: 8 },
-    string_format: { rules: [:only_printable_characters, :starts_with_non_whitespace, :ends_with_non_whitespace] }
+    string_format: { rules: [:only_printable_characters, :starts_with_non_whitespace, :ends_with_non_whitespace] },
+    allow_nil: true
 
   has_and_belongs_to_many :games
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -6,3 +6,4 @@ markoates:
   last_name: Oates
   website: www.example.com
   description: I like cats __and__ noodles!
+  password_digest: FaK3_pa5sw0rd_D1G3S+

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -97,6 +97,12 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.email, 'jumblecase@email.com'
   end
 
+  test 'password must be present on creation' do
+    User.destroy_all
+    user.password = nil
+    refute user.save
+  end
+
   test 'with a password less than 8 characters, is invalid' do
     user.password = 'pw2shrt'
     user.validate

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -121,6 +121,11 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:password], 'can only contain printable characters'
   end
 
+  test 'a password on an exiting user does not require re-validation' do
+    user_from_database = users(:markoates)
+    assert user_from_database.validate
+  end
+
   test 'generates a handle on validation' do
     user.validate
     assert_equal user.handle, 'mr-test'


### PR DESCRIPTION
## Problem

An odd thing occurs when attempting to resave a `User` after pulling it from the database.  Validation on `password` fails:

![user allegro planet admin 2017-03-06 22-05-43](https://cloud.githubusercontent.com/assets/772949/23640050/1a71156a-02b9-11e7-9339-9d941aa2e86b.png)

## Why

This peculiarity happens because `has_secure_password` actually does the validation and presence checks for `password` when it automatically generates the value for `password_digest`.   However, after the `password_digest` is present, the `password` field is set to `nil`.  As a result, any custom validations added on the model for `password` will fail after that point since `password` is set to `nil`.  So in our case, it is ok to have a `nil` password after creation.

An article discussing the issue [can be found here](https://quickleft.com/blog/rails-tip-validating-users-with-has_secure_password/).

## Solution

Add `allow_nil: true` to `User#password` validation.  Also, add tests to ensure the expected validations occur on create and update.