### PR TITLE
Safely escape inline HTML from Markdown

### DIFF
--- a/app/converters/markdown_converter.rb
+++ b/app/converters/markdown_converter.rb
@@ -16,6 +16,6 @@ class MarkdownConverter
   end
 
   def renderer
-    @renderer ||= Redcarpet::Render::HTML
+    @renderer ||= Redcarpet::Render::HTML.new(escape_html: true)
   end
 end

--- a/test/converters/markdown_converter_test.rb
+++ b/test/converters/markdown_converter_test.rb
@@ -23,4 +23,13 @@ class MarkdownConverterTest < ActiveSupport::TestCase
 
     assert_equal expected_html, returned_html
   end
+
+  test '#html safely escapes HTML characters and does not generate inline HTML' do
+    markdown_with_inline_html = "<script>alert('haxed');</script>"
+    returned_html = MarkdownConverter.new(markdown_with_inline_html).html
+    expected_escaped_html = "<p>&lt;script&gt;alert(&#39;haxed&#39;);&lt;/script&gt;</p>"
+
+    refute_match markdown_with_inline_html, returned_html
+    assert_match expected_escaped_html, returned_html
+ end
 end


### PR DESCRIPTION
## Problem

Currently the `MarkdownConverter` permits inline HTML. This can be a problem and could allow a malicious user to embed `<script></script>` tags that will run when loading that user's page.  At worst, this opens up a vulnerability for cross-site scripting.

## Solution

Configure the `MarkdownConverter` to escape HTML tags.  Add tests.

## Example

![xss](https://cloud.githubusercontent.com/assets/772949/23640886/36b76dc8-02be-11e7-9f47-5f54609d3227.png)