### PR TITLE
Improve admin hint on handle field when creating a Game

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -58,6 +58,7 @@ RailsAdmin.config do |config|
       configure :handle do
         read_only true
         help 'Generated automatically.'
+        visible { bindings[:object].id.present? }
       end
     end
   end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -57,6 +57,7 @@ RailsAdmin.config do |config|
         :updated_at
       configure :handle do
         read_only true
+        help 'Generated automatically.'
       end
     end
   end


### PR DESCRIPTION
## Problem

When creating a new `Game`, the `handle` param is marked as "Required". This can be confusing because there is no actual text input field. And, the `handle` param is automatically generated anyway.

![handle-required](https://cloud.githubusercontent.com/assets/772949/23829281/44443f50-06bc-11e7-895f-6cc77fcfa75f.png)

## Solution

- Prevent the field from being shown when creating a new Game.
- Customize the "help" message in Rails Admin so it reads as "Automatically generated" rather than "Required."

![game allegro planet admin 2017-03-12 00-40-12](https://cloud.githubusercontent.com/assets/772949/23829290/7a4e7c64-06bc-11e7-92ac-8a49a77828d1.png)

____

fixes https://github.com/allegroplanet/allegro-planet/issues/43
cc @allefant 