### PR TITLE
In Admin, configure GameFile category field as dropdown

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -71,6 +71,16 @@ RailsAdmin.config do |config|
     end
   end
 
+  # GameFile
+
+  config.model 'GameFile' do
+    configure :category, :enum do
+      enum do
+        GameFile::GAME_FILE_CATEGORIES.each.collect { |element| [element] }
+      end
+    end
+  end
+
   def game_release_label_method
     "#{self.game.handle}-#{self.version_num}"
   end


### PR DESCRIPTION
# Problem

A `GameFile` must belong to one of several categories:

```
['MacOS binary', 'Win binary', 'Linux binary', 'Data files', 'Source files', 'Other']
```
In admin you have to input this value into a text input field, and there is no clue that it must be one of the types.  Also, the error message only appears _after_ you upload the file.

# Solution

Use a dropdown that lists only the allowed values.

## Before

![ugh - game file allegro planet admin 2017-03-12 01-03-10](https://cloud.githubusercontent.com/assets/772949/23829487/acd35ea8-06c0-11e7-8bc3-cdea06980865.png)

## After

![after - localhost 3000 admin game_file new 2017-03-12 01-01-49](https://cloud.githubusercontent.com/assets/772949/23829489/b1d61d14-06c0-11e7-8040-7fb43628679e.png)


___

fixes https://github.com/allegroplanet/allegro-planet/issues/42
cc @allefant 