### PR TITLE
Image versions for game screenshots

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -6,7 +6,13 @@ class GamesController < ApplicationController
   def show
     @game = Game.find_by(handle: params[:handle]) or record_not_found
     @description = MarkdownConverter.new(@game.description).html
-    @screenshot_urls = @game.game_screenshots.collect { |s| s.public_url }
+    @feature_screenshot_urls = feature_screenshot_urls
     @releases = @game.game_releases.collect { |r| GameReleaseDecorator.new(r) }
+  end
+
+  def feature_screenshot_urls
+    @screenshot_urls ||= @game.game_screenshots.collect do |s|
+      s.feature_public_url
+    end
   end
 end

--- a/app/models/game_screenshot.rb
+++ b/app/models/game_screenshot.rb
@@ -3,7 +3,9 @@ class GameScreenshot < ApplicationRecord
 
   belongs_to :game
 
-  def public_url
-    "https://#{Figaro.env.aws_allegro_planet_bucket}.s3.amazonaws.com/#{image.path}"
+  private
+
+  def public_url(image_path)
+    "https://#{Figaro.env.aws_allegro_planet_bucket}.s3.amazonaws.com/#{image_path}"
   end
 end

--- a/app/models/game_screenshot.rb
+++ b/app/models/game_screenshot.rb
@@ -3,6 +3,18 @@ class GameScreenshot < ApplicationRecord
 
   belongs_to :game
 
+  def feature_public_url
+    public_url(image.feature.path)
+  end
+
+  def thumb_public_url
+    public_url(image.thumb.path)
+  end
+
+  def tile_public_url
+    public_url(image.tile.path)
+  end
+
   private
 
   def public_url(image_path)

--- a/app/uploaders/game_screenshot_uploader.rb
+++ b/app/uploaders/game_screenshot_uploader.rb
@@ -1,6 +1,24 @@
 class GameScreenshotUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MiniMagick
+
+  VERSION_FEATURE_SIZE = [640, 360] # 1/3 HD
+  VERSION_TILE_SIZE    = [320, 180] # 1/6 HD
+  VERSION_THUMB_SIZE   = [160, 90]  # 1/12 HD
+
   def store_dir
     'screenshots'
+  end
+
+  version :feature do
+    process resize_to_fit: VERSION_FEATURE_SIZE
+  end
+
+  version :tile do
+    process resize_and_pad: VERSION_TILE_SIZE
+  end
+
+  version :thumb do
+    process resize_and_pad: VERSION_THUMB_SIZE
   end
 
   def extension_whitelist

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -5,8 +5,8 @@
 
 <h3>Screenshots (<%= @game.game_screenshots.count %>)</h3>
 <div>
-  <% @screenshot_urls.each do |screenshot_url| %>
-    <%= image_tag(screenshot_url) %>
+  <% @feature_screenshot_urls.each do |feature_screenshot_url| %>
+    <%= image_tag(feature_screenshot_url) %>
   <% end %>
 </div>
 

--- a/test/models/game_screenshot_test.rb
+++ b/test/models/game_screenshot_test.rb
@@ -9,10 +9,4 @@ class GameScreenshotTest < ActiveSupport::TestCase
     associations = game_screenshot_associations(:belongs_to, :game)
     assert associations.one?
   end
-
-  test '#public_url returns the expected url' do
-    returned_url = game_screenshots(:alex_screenshot_1).public_url
-    expected_url = "https://test-buhkit.s3.amazonaws.com/screenshots/title-screen-screenshot.jpg"
-    assert_equal expected_url, returned_url
-  end
 end

--- a/test/models/game_screenshot_test.rb
+++ b/test/models/game_screenshot_test.rb
@@ -9,4 +9,22 @@ class GameScreenshotTest < ActiveSupport::TestCase
     associations = game_screenshot_associations(:belongs_to, :game)
     assert associations.one?
   end
+
+  test '#feature_public_url returns the expected url' do
+    returned_url = game_screenshots(:alex_screenshot_1).feature_public_url
+    expected_url = "https://test-buhkit.s3.amazonaws.com/screenshots/feature_title-screen-screenshot.jpg"
+    assert_equal expected_url, returned_url
+  end
+
+  test '#tile_public_url returns the expected url' do
+    returned_url = game_screenshots(:alex_screenshot_1).tile_public_url
+    expected_url = "https://test-buhkit.s3.amazonaws.com/screenshots/tile_title-screen-screenshot.jpg"
+    assert_equal expected_url, returned_url
+  end
+
+  test '#thumb_public_url returns the expected url' do
+    returned_url = game_screenshots(:alex_screenshot_1).thumb_public_url
+    expected_url = "https://test-buhkit.s3.amazonaws.com/screenshots/thumb_title-screen-screenshot.jpg"
+    assert_equal expected_url, returned_url
+  end
 end


### PR DESCRIPTION
## Problem

Uploaded `GameScreenshots` are not standard sized.  Right now on the `GamesController#show` page, images are displayed at full resolution.

## Solution

Enable CarrierWave to create "versions" of the screenshot on upload.  The versions are:

```
  VERSION_FEATURE_SIZE = [640, 360] # 1/3 HD
  VERSION_TILE_SIZE    = [320, 180] # 1/6 HD
  VERSION_THUMB_SIZE   = [160, 90]  # 1/12 HD
```

Also, only show the `feature` version in `GameController#show`

## ⚠️ Warning

`GameScreenshots` that have been uploaded already will need to be re-uploaded so they can be processed.

____

cc @allefant 
fixes https://github.com/allegroplanet/allegro-planet/issues/37