### PR TITLE
Add flickity photo carousel

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -20,3 +20,11 @@
 
 body
   background: image-url('space_background-01.jpg') 50% 0 no-repeat
+
+.carousel-wrapper
+  padding-bottom: 10px
+
+.carousel-cell
+  height: 360px
+  margin-left: 6px
+  margin-right: 6px

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,27 +1,35 @@
-<h1><%= @game.title %></h1>
-
-<h3>Description</h3>
-<div><%= @description %></div>
-
-<h3>Screenshots (<%= @game.game_screenshots.count %>)</h3>
-<div>
-  <% @feature_screenshot_urls.each do |feature_screenshot_url| %>
-    <%= image_tag(feature_screenshot_url) %>
-  <% end %>
+<div class="row">
+  <h1><%= @game.title %></h1>
 </div>
 
-<h3>Releases (<%= @releases.count %>)</h3>
-<div>
-  <% @releases.each do |release| %>
-    <h4><%= release.version_num %></h4>
-    <div><%= release.notes %></div>
-    <h5>Files</h5>
-    <div>
-      <ul>
-      <% release.game_files.each do |game_file| %>
-        <li><%= link_to(game_file[:category], game_file[:public_url]) %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+<div class="row">
+  <h3>Description</h3>
+  <div><%= @description %></div>
+</div>
+
+<div class="row">
+  <h3>Screenshots (<%= @game.game_screenshots.count %>)</h3>
+  <div>
+    <% @feature_screenshot_urls.each do |feature_screenshot_url| %>
+      <%= image_tag(feature_screenshot_url) %>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <h3>Releases (<%= @releases.count %>)</h3>
+  <div>
+    <% @releases.each do |release| %>
+      <h4><%= release.version_num %></h4>
+      <div><%= release.notes %></div>
+      <h5>Files</h5>
+      <div>
+        <ul>
+        <% release.game_files.each do |game_file| %>
+          <li><%= link_to(game_file[:category], game_file[:public_url]) %></li>
+        <% end %>
+        </ul>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -9,11 +9,7 @@
 
 <div class="row">
   <h3>Screenshots (<%= @game.game_screenshots.count %>)</h3>
-  <div>
-    <% @feature_screenshot_urls.each do |feature_screenshot_url| %>
-      <%= image_tag(feature_screenshot_url) %>
-    <% end %>
-  </div>
+  <%= render 'shared/flickity', image_urls: @feature_screenshot_urls %>
 </div>
 
 <div class="row">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <link rel="stylesheet" href="https://bootswatch.com/cyborg/bootstrap.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/flickity@2/dist/flickity.min.css">
+    <script src="https://unpkg.com/flickity@2/dist/flickity.pkgd.min.js"></script>
   </head>
 
   <body>

--- a/app/views/shared/_flickity.html.erb
+++ b/app/views/shared/_flickity.html.erb
@@ -1,0 +1,7 @@
+<div class="carousel-wrapper">
+  <div class="carousel" data-flickity='{ "imagesLoaded": true, "autoPlay": true, "wrapAround": true }'>
+    <% image_urls.each do |image_url| %>
+      <div class="carousel-cell"><%= image_tag(image_url) %></div>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
## Problem

In `GameController`'s show page, screenshots are simply placed on the page as image tags.  It's not a very user-friendly experience.

## Solution

Use the [Flickity](http://flickity.metafizzy.co/) carousel to group multiple images into a single carousel.

## Example

![allegroplanet 2017-03-19 00-55-52](https://cloud.githubusercontent.com/assets/772949/24078234/d59ba0f6-0c3e-11e7-962a-48379ddedcf8.png)
