### PR TITLE
Support GitHub Webhooks

### DIFF
--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -1,0 +1,20 @@
+class GithubWebhooksController < ApplicationController
+  def create
+    GithubWebhook.create!(event: github_event_header, payload_json: payload_param)
+    render json: { success: true }
+  end
+
+  def index
+    @webhooks = GithubWebhook.order(created_at: :desc)
+  end
+
+  private
+
+  def payload_param
+    params[:payload]
+  end
+
+  def github_event_header
+    request.env['HTTP_X_GITHUB_EVENT']
+  end
+end

--- a/app/models/github_webhook.rb
+++ b/app/models/github_webhook.rb
@@ -1,0 +1,2 @@
+class GithubWebhook < ApplicationRecord
+end

--- a/app/models/github_webhook.rb
+++ b/app/models/github_webhook.rb
@@ -1,2 +1,4 @@
 class GithubWebhook < ApplicationRecord
+  validates :event, length: { maximum: 32 }
+  validates :payload_json, length: { maximum: 512 }
 end

--- a/app/views/github_webhooks/index.html.erb
+++ b/app/views/github_webhooks/index.html.erb
@@ -1,0 +1,13 @@
+<div class="row">
+  <h1>Github Webhooks</h1>
+</div>
+
+<div class="row">
+  <div>
+    <ul>
+    <% @webhooks.each do |webhook| %>
+      <li><%= webhook.event %> : <%= webhook.created_at %><pre><%= webhook.payload_json %></pre><li>
+    <% end %>
+    </ul>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
 
   get '/search', to: 'search#index', param: :q
 
+  resources :github_webhooks, only: [:create, :index]
+
   resources :games, param: :handle, only: [:index, :show]
 
   resources :users, param: :handle, only: [:show]

--- a/db/migrate/20171008153311_add_github_webhooks.rb
+++ b/db/migrate/20171008153311_add_github_webhooks.rb
@@ -1,0 +1,9 @@
+class AddGithubWebhooks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :github_webhooks do |t|
+      t.string :event
+      t.text :payload_json
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,65 +10,72 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302064617) do
+ActiveRecord::Schema.define(version: 20171008153311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "game_files", force: :cascade do |t|
-    t.string   "file"
-    t.string   "category"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.integer  "game_release_id"
-    t.index ["game_release_id"], name: "index_game_files_on_game_release_id", using: :btree
-  end
-
-  create_table "game_releases", force: :cascade do |t|
-    t.string   "version_num"
-    t.text     "notes"
-    t.integer  "game_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["game_id"], name: "index_game_releases_on_game_id", using: :btree
-  end
-
-  create_table "game_screenshots", force: :cascade do |t|
-    t.string   "image"
-    t.integer  "game_id"
+  create_table "game_files", id: :serial, force: :cascade do |t|
+    t.string "file"
+    t.string "category"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["game_id"], name: "index_game_screenshots_on_game_id", using: :btree
+    t.integer "game_release_id"
+    t.index ["game_release_id"], name: "index_game_files_on_game_release_id"
   end
 
-  create_table "games", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.string   "handle"
-    t.index ["handle"], name: "index_games_on_handle", using: :btree
+  create_table "game_releases", id: :serial, force: :cascade do |t|
+    t.string "version_num"
+    t.text "notes"
+    t.integer "game_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id"], name: "index_game_releases_on_game_id"
+  end
+
+  create_table "game_screenshots", id: :serial, force: :cascade do |t|
+    t.string "image"
+    t.integer "game_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id"], name: "index_game_screenshots_on_game_id"
+  end
+
+  create_table "games", id: :serial, force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "handle"
+    t.index ["handle"], name: "index_games_on_handle"
   end
 
   create_table "games_users", id: false, force: :cascade do |t|
     t.integer "game_id"
     t.integer "user_id"
-    t.index ["game_id"], name: "index_games_users_on_game_id", using: :btree
-    t.index ["user_id"], name: "index_games_users_on_user_id", using: :btree
+    t.index ["game_id"], name: "index_games_users_on_game_id"
+    t.index ["user_id"], name: "index_games_users_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "username"
-    t.string   "email"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "website"
-    t.text     "description"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.string   "password_digest"
-    t.string   "handle"
-    t.index ["handle"], name: "index_users_on_handle", using: :btree
+  create_table "github_webhooks", force: :cascade do |t|
+    t.string "event"
+    t.text "payload_json"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "username"
+    t.string "email"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "website"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "password_digest"
+    t.string "handle"
+    t.index ["handle"], name: "index_users_on_handle"
   end
 
   add_foreign_key "game_releases", "games"

--- a/test/controllers/github_webhooks_controller_test.rb
+++ b/test/controllers/github_webhooks_controller_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class GithubWebhooksControllerTest < ActionDispatch::IntegrationTest
+  def github_webhook
+    @github_webhook ||= github_webhooks(:new_pull_request)
+  end
+
+  test 'GET #create is successful' do
+    post github_webhooks_path, params: { payload: "asdf" }
+    assert_response :success
+  end
+
+  test 'GET #create creates a new GithubWebhook' do
+    GithubWebhook.destroy_all
+
+    payload = '{ "hello": "true" }'
+    event = 'pull-request'
+
+    post github_webhooks_path, params: { payload: payload }, headers: { 'X-GitHub-Event' => event }
+
+    assert_equal event, GithubWebhook.first.event
+    assert_equal payload, GithubWebhook.first.payload_json
+  end
+
+  test 'GET #index is successful' do
+    get github_webhooks_path(github_webhook)
+    assert_response :success
+  end
+
+  test 'GET #index renders the "index" template' do
+    get github_webhooks_path(github_webhook)
+    assert_template :index
+  end
+end

--- a/test/fixtures/github_webhooks.yml
+++ b/test/fixtures/github_webhooks.yml
@@ -1,0 +1,3 @@
+new_pull_request:
+  event: pull-request
+  payload_json: '{ "status": "200" }'

--- a/test/models/github_webhook_test.rb
+++ b/test/models/github_webhook_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class GithubWebhookTest < ActiveSupport::TestCase
+  def github_webhook
+    @github_webhook ||= GithubWebhook.new(event: 'pull-request', payload_json: '{ "status": "200" }')
+  end
+
+  test 'validates without errors' do
+    github_webhook.validate
+    assert github_webhook.errors.empty?
+  end
+
+  test 'with a event larger than 32 characters, is invalid' do
+    github_webhook.event = 'x' * 33
+    github_webhook.validate
+    assert_includes github_webhook.errors[:event], 'is too long (maximum is 32 characters)'
+  end
+
+  test 'with a payload_json larger than 512 characters, is invalid' do
+    github_webhook.payload_json = 'x' * 516
+    github_webhook.validate
+    assert_includes github_webhook.errors[:payload_json], 'is too long (maximum is 512 characters)'
+  end
+end


### PR DESCRIPTION
In order for Allegro Planet to begin working toward advanced features like remote build and CI, it will need to have support webhooks from GitHub.

In this simplest iteration, I'll add an endpoint at `/github_webhooks` that will simply take whatever data is passed to it, and store it as a `GithubWebhook` record.  Later, we can figure out what features to extract, and what actions we want to take on it.  Note that this feature also does not yet provide any restrictions on a requester and can receive calls from anywhere, not just from GitHub.

See the [GitHub docs on creating a CI server](https://developer.github.com/v3/guides/building-a-ci-server/) for more detail.