### PR TITLE
Allow Webhook Access

### DIFF
--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -1,4 +1,6 @@
 class GithubWebhooksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def create
     GithubWebhook.create!(event: github_event_header, payload_json: payload_param)
     render json: { success: true }

--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -10,7 +10,15 @@ class GithubWebhooksController < ApplicationController
     @webhooks = GithubWebhook.order(created_at: :desc)
   end
 
+  def show
+    @webhook = GithubWebhook.find(id_param)
+  end
+
   private
+
+  def id_param
+    params[:id]
+  end
 
   def payload_param
     params[:payload]

--- a/app/models/github_webhook.rb
+++ b/app/models/github_webhook.rb
@@ -1,4 +1,3 @@
 class GithubWebhook < ApplicationRecord
   validates :event, length: { maximum: 32 }
-  validates :payload_json, length: { maximum: 512 }
 end

--- a/app/views/github_webhooks/index.html.erb
+++ b/app/views/github_webhooks/index.html.erb
@@ -6,7 +6,7 @@
   <div>
     <ul>
     <% @webhooks.each do |webhook| %>
-      <li><%= webhook.event %> : <%= webhook.created_at %><pre><%= webhook.payload_json %></pre><li>
+      <li><%= webhook.id %> &bull; <%= webhook.event %> &bull; <%= webhook.created_at %></li>
     <% end %>
     </ul>
   </div>

--- a/app/views/github_webhooks/show.html.erb
+++ b/app/views/github_webhooks/show.html.erb
@@ -1,0 +1,11 @@
+<div class="row">
+  <h1>Github Webhook</h1>
+</div>
+
+<div class="row">
+  <div>
+    <h4><%= @webhook.event %></h4>
+    <p><%= @webhook.created_at %></p>
+    <pre><%= @webhook.payload_json %></pre>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   get '/search', to: 'search#index', param: :q
 
-  resources :github_webhooks, only: [:create, :index]
+  resources :github_webhooks, only: [:create, :index, :show]
 
   resources :games, param: :handle, only: [:index, :show]
 

--- a/test/controllers/github_webhooks_controller_test.rb
+++ b/test/controllers/github_webhooks_controller_test.rb
@@ -22,6 +22,16 @@ class GithubWebhooksControllerTest < ActionDispatch::IntegrationTest
     assert_equal payload, GithubWebhook.first.payload_json
   end
 
+  test 'GET #show is successful' do
+    get github_webhook_path(github_webhook)
+    assert_response :success
+  end
+
+  test 'GET #show renders the "show" template' do
+    get github_webhook_path(github_webhook)
+    assert_template :show
+  end
+
   test 'GET #index is successful' do
     get github_webhooks_path(github_webhook)
     assert_response :success

--- a/test/models/github_webhook_test.rb
+++ b/test/models/github_webhook_test.rb
@@ -15,10 +15,4 @@ class GithubWebhookTest < ActiveSupport::TestCase
     github_webhook.validate
     assert_includes github_webhook.errors[:event], 'is too long (maximum is 32 characters)'
   end
-
-  test 'with a payload_json larger than 512 characters, is invalid' do
-    github_webhook.payload_json = 'x' * 516
-    github_webhook.validate
-    assert_includes github_webhook.errors[:payload_json], 'is too long (maximum is 512 characters)'
-  end
 end


### PR DESCRIPTION
GitHub Webhooks currently hit Allegro Planet and Planet responds with a 422.  This is due to a requirement on rails that controllers actions can only be called with an "authenticity token".  Since no token exists when a webhook hits, rails responds with an error.

Also, GitHub Webooks post a pretty large payload.  This means the length validation of a maximum length of 512 will not work with this property.  Also, rather than showing the payloads with each item on the index page, it's better to move them to a show page and reduce the footprint on the index page.