### PR TITLE
Use Request Body as Param for Webhook Payload

### DIFF
--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -21,7 +21,7 @@ class GithubWebhooksController < ApplicationController
   end
 
   def payload_param
-    params[:payload]
+    request.raw_post
   end
 
   def github_event_header


### PR DESCRIPTION
Due [to the tutorial](https://developer.github.com/v3/guides/building-a-ci-server/), it was assumed the payload would be provided in `params[:payload]`.  However, it's actually in the body, which can be pulled from `request.raw_post`.

Related: https://github.com/allegroplanet/allegro-planet/pull/55, https://github.com/allegroplanet/allegro-planet/pull/56