### PR TITLE
Add Published Status to Article

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -17,6 +17,8 @@ class Article < ApplicationRecord
   validates :published,
     presence: true
 
+  scope :published, -> { where(published: true) }
+
   def to_param
     handle
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -14,6 +14,8 @@ class Article < ApplicationRecord
     presence: true,
     allow_blank: false,
     string_format: { rules: [:only_printable_characters_and_newlines] }
+  validates :published,
+    presence: true
 
   def to_param
     handle

--- a/db/migrate/20191020182233_add_published_to_article.rb
+++ b/db/migrate/20191020182233_add_published_to_article.rb
@@ -1,0 +1,5 @@
+class AddPublishedToArticle < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :published, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_20_170531) do
+ActiveRecord::Schema.define(version: 2019_10_20_182233) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_10_20_170531) do
     t.text "body_markdown", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "published", default: true, null: false
     t.index ["handle"], name: "index_articles_on_handle"
   end
 

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -4,3 +4,11 @@ basic_tutorial:
   body_markdown: |
     Welcome to this amazing article!
   published: true
+
+an_unpublished_tutorial:
+  handle: unpublished-tutorial
+  title: Unpublished Tutorial
+  body_markdown: |
+    Welcome to this amazing article!  It's a work in progress.  I'm not going to release it until it's in just
+    fantastic shape!
+  published: false

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -3,3 +3,4 @@ basic_tutorial:
   title: Basic Tutorial
   body_markdown: |
     Welcome to this amazing article!
+  published: true

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -123,4 +123,13 @@ class ArticleTest < ActiveSupport::TestCase
 
     assert_includes article.errors[:published], "can't be blank"
   end
+
+  test "The published scope returns only articles that are marked as published" do
+    assert Article.where(published: false).any?
+    assert Article.where(published: true).any?
+
+    expected_published_articles = Article.where(published: true)
+
+    assert_equal expected_published_articles, Article.published
+  end
 end

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -115,4 +115,12 @@ class ArticleTest < ActiveSupport::TestCase
 
     assert_equal expected_param, article.to_param
   end
+
+  test "published must be present" do
+    article = articles(:basic_tutorial)
+    article.published = nil
+    article.validate
+
+    assert_includes article.errors[:published], "can't be blank"
+  end
 end


### PR DESCRIPTION
## Problem

Right now, any and all articles that exist in the database are subject to being displayed once the view and controller are created.

## Solution

Add a `published` status.  This will allow authors to create "pending" articles, or allow admins to easily disable articles from public view.

* Also included, is a `published` _scope_ on the `Article` model.  This will more easily allow the filtering of `published` articles for views and other lists.

_________

This is actually part 4 of https://github.com/allegroplanet/allegro-planet/issues/63