### PR TITLE
Fix presence validation on boolean "published" for Article

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -15,7 +15,7 @@ class Article < ApplicationRecord
     allow_blank: false,
     string_format: { rules: [:only_printable_characters_and_newlines] }
   validates :published,
-    presence: true
+    inclusion: { in: [true, false], message: 'must be either true or false' }
 
   scope :published, -> { where(published: true) }
 

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -121,7 +121,20 @@ class ArticleTest < ActiveSupport::TestCase
     article.published = nil
     article.validate
 
-    assert_includes article.errors[:published], "can't be blank"
+    assert_includes article.errors[:published], 'must be either true or false'
+  end
+
+  test "published can be either true or false" do
+    article = articles(:basic_tutorial)
+
+    valid_published_values = [ true, false, ]
+
+    valid_published_values.each do |valid_published_value|
+      article.published = valid_published_value
+      article.validate
+
+      assert_empty article.errors[:published]
+    end
   end
 
   test "The published scope returns only articles that are marked as published" do


### PR DESCRIPTION
## Problem

Currently, it's not possible to set an article's `published` to `false`!  Because of the way Rails handles `presence` validations, a `false` value indicates to Rails that the value is not present.

## Solution

To fix this, I'll replace the `presence: true` validation with a `inclusion: { in: [true, false]}`, along with an error message.  This will still prevent `nil` values from being permitted, as is indicated by an updated test.

_____

This is a fix to https://github.com/allegroplanet/allegro-planet/pull/65