### PR TITLE
Add Articles Controller, Routes, and Basic Rendering

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -34,5 +34,4 @@ nav
 
 div.article
   width: 600px
-  h1.title
-  div.body
+  margin: auto

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -31,3 +31,8 @@ nav
       vertical-align: middle
       a
         text-decoration: none
+
+div.article
+  width: 600px
+  h1.title
+  div.body

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,10 +1,10 @@
 class ArticlesController < ApplicationController
   def index
-    @articles = Article.all
+    @articles = Article.published
   end
 
   def show
-    article = Article.find_by(handle: article_handle_param)
+    article = Article.published.find_by(handle: article_handle_param) or record_not_found
 
     @title = article.title
     @body_html = MarkdownConverter.new(article.body_markdown).html

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,0 +1,18 @@
+class ArticlesController < ApplicationController
+  def index
+    @articles = Article.all
+  end
+
+  def show
+    article = Article.find_by(handle: article_handle_param)
+
+    @title = article.title
+    @body_html = MarkdownConverter.new(article.body_markdown).html
+  end
+
+  private
+
+  def article_handle_param
+    params.permit(:handle)[:handle]
+  end
+end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,0 +1,7 @@
+<h1>Articles</h1>
+
+<ul>
+  <% @articles.each do |article| %>
+    <li><%= link_to(article.title, article) %></li>
+  <% end %>
+</ul>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,0 +1,6 @@
+<div class="article">
+  <h1 class="title"><%= @title %></h1>
+  <div class="body">
+    <%= @body_html %>
+  </div>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -4,6 +4,7 @@
       <a href="/"><%= image_tag("allegro_planet_logo-01c.png", width: '80px') %><%= image_tag("allegro-planet-text-logo.svg", width: "300px") %></a>
     </li>
 
+    <li><a href="/articles">Articles</a></li>
     <li><a href="/games">Games</a></li>
     <li><a href="/users">Users</a></li>
   </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   end
 
   resources :users, param: :handle, only: [:index, :show]
+  resources :articles, param: :handle, only: [:index, :show]
+
   get '/signup', to: 'users#new'
   post '/signup', to: 'users#create'
 end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ArticlesControllerTest < ActionDispatch::IntegrationTest
+  test "the truth" do
+    assert true
+  end
+end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -1,7 +1,54 @@
 require 'test_helper'
 
 class ArticlesControllerTest < ActionDispatch::IntegrationTest
-  test "the truth" do
-    assert true
+  test 'GET #index is successful' do
+    get articles_url
+    assert_response :success
+  end
+
+  test 'GET #index lists published articles' do
+    expected_article_titles = Article.published.pluck(:title)
+    refute_empty expected_article_titles
+
+    get articles_url
+
+    expected_article_titles.each do |expected_article_title|
+      assert_match expected_article_title, response.body
+    end
+  end
+
+  test 'GET #index does not list unpublished articles' do
+    unexpected_article_titles = Article.where(published: false).pluck(:title)
+    refute_empty unexpected_article_titles
+
+    get articles_url
+
+    unexpected_article_titles.each do |unexpected_article_title|
+      refute_match unexpected_article_title, response.body
+    end
+  end
+
+  test 'GET #show is successful' do
+    get article_path(articles(:basic_tutorial))
+    assert_response :success
+  end
+
+  test 'GET #show includes the article title and body converted from markdown' do
+    article = articles(:basic_tutorial)
+    get article_path(article)
+
+    expected_article_title = article.title
+    expected_article_body = MarkdownConverter.new(article.body_markdown).html
+
+    assert_match expected_article_title, response.body
+    assert_match expected_article_body, response.body
+  end
+
+  test 'GET #show will raise RecordNotFound when attempting to view an unpublished article' do
+    unpublished_article = articles(:an_unpublished_tutorial)
+
+    assert_raise ActiveRecord::RecordNotFound do
+      get article_path(unpublished_article)
+    end
   end
 end


### PR DESCRIPTION
## Problem

This is part 2 of https://github.com/allegroplanet/allegro-planet/issues/63.  Currently, articles are only visible via the console.  They do not display anywhere on the website.

## Solution

This PR adds the basic features for showing articles on Allegro Planet.

* A list of articles located at `/articles`
* Individual article routes are automatically generated based on title, and appear at paths like `/articles/title-of-the-article`
* Only published articles can be seen
* A new link to "Articles" is added in the navbar
* Minimal styling is included. (Essentially no front-end work is included in this PR.)
