### PR TITLE
Add "Article" Records in Admin

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -19,6 +19,23 @@ RailsAdmin.config do |config|
     show_in_app
   end
 
+  # Article
+
+  config.model 'Article' do
+    object_label_method do
+      :title
+    end
+
+    edit do
+      field :title
+      field :handle do
+        read_only true
+        help "Auto-generated based on title."
+      end
+      field :body_markdown
+    end
+  end
+
   # User
 
   config.model 'User' do


### PR DESCRIPTION
## Problem

Articles are listed and can be displayed on the web, but the only way to create them is by logging into the shell.

## Solution

Add the model to the RailsAdmin config. For now, this will give admins access and they will be able to add/edit/create articles.

In the future, each user should have the ability to create articles (along with games and releases) through a dashboard, and should not be restricted to administrators.